### PR TITLE
Clean up jquery-ui-i18n and set proper default

### DIFF
--- a/Resources/public/jquery-ui-i18n.js
+++ b/Resources/public/jquery-ui-i18n.js
@@ -19,12 +19,9 @@ jQuery(function($){
 		isRTL: false,
 		showMonthAfterYear: false,
 		yearSuffix: ''};
-	$.datepicker.setDefaults($.datepicker.regional['af']);
-});
+
 /* Algerian Arabic Translation for jQuery UI date picker plugin. (can be used for Tunisia)*/
 /* Mohamed Cherif BOUCHELAGHEM -- cherifbouchelaghem@yahoo.fr */
-
-jQuery(function($){
 	$.datepicker.regional['ar-DZ'] = {
 		closeText: 'إغلاق',
 		prevText: '&#x3c;السابق',
@@ -42,12 +39,10 @@ jQuery(function($){
   		isRTL: true,
 		showMonthAfterYear: false,
 		yearSuffix: ''};
-	$.datepicker.setDefaults($.datepicker.regional['ar-DZ']);
-});
+
 /* Arabic Translation for jQuery UI date picker plugin. */
 /* Khaled Alhourani -- me@khaledalhourani.com */
 /* NOTE: monthNames are the original months names and they are the Arabic names, not the new months name فبراير - يناير and there isn't any Arabic roots for these months */
-jQuery(function($){
 	$.datepicker.regional['ar'] = {
 		closeText: 'إغلاق',
 		prevText: '&#x3c;السابق',
@@ -65,10 +60,9 @@ jQuery(function($){
   		isRTL: true,
 		showMonthAfterYear: false,
 		yearSuffix: ''};
-	$.datepicker.setDefaults($.datepicker.regional['ar']);
-});/* Azerbaijani (UTF-8) initialisation for the jQuery UI date picker plugin. */
+
+/* Azerbaijani (UTF-8) initialisation for the jQuery UI date picker plugin. */
 /* Written by Jamil Najafov (necefov33@gmail.com). */
-jQuery(function($) {
 	$.datepicker.regional['az'] = {
 		closeText: 'Bağla',
 		prevText: '&#x3c;Geri',
@@ -87,15 +81,14 @@ jQuery(function($) {
 		isRTL: false,
 		showMonthAfterYear: false,
 		yearSuffix: ''};
-	$.datepicker.setDefaults($.datepicker.regional['az']);
-});/* Bulgarian initialisation for the jQuery UI date picker plugin. */
+
+/* Bulgarian initialisation for the jQuery UI date picker plugin. */
 /* Written by Stoyan Kyosev (http://svest.org). */
-jQuery(function($){
     $.datepicker.regional['bg'] = {
         closeText: 'затвори',
         prevText: '&#x3c;назад',
         nextText: 'напред&#x3e;',
-		nextBigText: '&#x3e;&#x3e;',
+	nextBigText: '&#x3e;&#x3e;',
         currentText: 'днес',
         monthNames: ['Януари','Февруари','Март','Април','Май','Юни',
         'Юли','Август','Септември','Октомври','Ноември','Декември'],
@@ -104,17 +97,15 @@ jQuery(function($){
         dayNames: ['Неделя','Понеделник','Вторник','Сряда','Четвъртък','Петък','Събота'],
         dayNamesShort: ['Нед','Пон','Вто','Сря','Чет','Пет','Съб'],
         dayNamesMin: ['Не','По','Вт','Ср','Че','Пе','Съ'],
-		weekHeader: 'Wk',
+	weekHeader: 'Wk',
         dateFormat: 'dd.mm.yy',
-		firstDay: 1,
+	firstDay: 1,
         isRTL: false,
-		showMonthAfterYear: false,
-		yearSuffix: ''};
-    $.datepicker.setDefaults($.datepicker.regional['bg']);
-});
+	showMonthAfterYear: false,
+	yearSuffix: ''};
+
 /* Bosnian i18n for the jQuery UI date picker plugin. */
 /* Written by Kenan Konjo. */
-jQuery(function($){
 	$.datepicker.regional['bs'] = {
 		closeText: 'Zatvori', 
 		prevText: '&#x3c;', 
@@ -133,10 +124,9 @@ jQuery(function($){
 		isRTL: false,
 		showMonthAfterYear: false,
 		yearSuffix: ''};
-	$.datepicker.setDefaults($.datepicker.regional['bs']);
-});/* Inicialització en català per a l'extenció 'calendar' per jQuery. */
+
+/* Inicialització en català per a l'extenció 'calendar' per jQuery. */
 /* Writers: (joan.leon@gmail.com). */
-jQuery(function($){
 	$.datepicker.regional['ca'] = {
 		closeText: 'Tancar',
 		prevText: '&#x3c;Ant',
@@ -155,10 +145,9 @@ jQuery(function($){
 		isRTL: false,
 		showMonthAfterYear: false,
 		yearSuffix: ''};
-	$.datepicker.setDefaults($.datepicker.regional['ca']);
-});/* Czech initialisation for the jQuery UI date picker plugin. */
+
+/* Czech initialisation for the jQuery UI date picker plugin. */
 /* Written by Tomas Muller (tomas@tomas-muller.net). */
-jQuery(function($){
 	$.datepicker.regional['cs'] = {
 		closeText: 'Zavřít',
 		prevText: '&#x3c;Dříve',
@@ -177,11 +166,9 @@ jQuery(function($){
 		isRTL: false,
 		showMonthAfterYear: false,
 		yearSuffix: ''};
-	$.datepicker.setDefaults($.datepicker.regional['cs']);
-});
+
 /* Danish initialisation for the jQuery UI date picker plugin. */
 /* Written by Jan Christensen ( deletestuff@gmail.com). */
-jQuery(function($){
     $.datepicker.regional['da'] = {
 		closeText: 'Luk',
         prevText: '&#x3c;Forrige',
@@ -200,11 +187,9 @@ jQuery(function($){
 		isRTL: false,
 		showMonthAfterYear: false,
 		yearSuffix: ''};
-    $.datepicker.setDefaults($.datepicker.regional['da']);
-});
+
 /* German initialisation for the jQuery UI date picker plugin. */
 /* Written by Milian Wolff (mail@milianw.de). */
-jQuery(function($){
 	$.datepicker.regional['de'] = {
 		closeText: 'schließen',
 		prevText: '&#x3c;zurück',
@@ -223,11 +208,9 @@ jQuery(function($){
 		isRTL: false,
 		showMonthAfterYear: false,
 		yearSuffix: ''};
-	$.datepicker.setDefaults($.datepicker.regional['de']);
-});
+
 /* Greek (el) initialisation for the jQuery UI date picker plugin. */
 /* Written by Alex Cicovic (http://www.alexcicovic.com) */
-jQuery(function($){
 	$.datepicker.regional['el'] = {
 		closeText: 'Κλείσιμο',
 		prevText: 'Προηγούμενος',
@@ -246,10 +229,9 @@ jQuery(function($){
 		isRTL: false,
 		showMonthAfterYear: false,
 		yearSuffix: ''};
-	$.datepicker.setDefaults($.datepicker.regional['el']);
-});/* English/Australia initialisation for the jQuery UI date picker plugin. */
+
+/* English/Australia initialisation for the jQuery UI date picker plugin. */
 /* Based on the en-GB initialisation. */
-jQuery(function($){
 	$.datepicker.regional['en-AU'] = {
 		closeText: 'Done',
 		prevText: 'Prev',
@@ -268,11 +250,9 @@ jQuery(function($){
 		isRTL: false,
 		showMonthAfterYear: false,
 		yearSuffix: ''};
-	$.datepicker.setDefaults($.datepicker.regional['en-AU']);
-});
+
 /* English/UK initialisation for the jQuery UI date picker plugin. */
 /* Written by Stuart. */
-jQuery(function($){
 	$.datepicker.regional['en-GB'] = {
 		closeText: 'Done',
 		prevText: 'Prev',
@@ -291,11 +271,9 @@ jQuery(function($){
 		isRTL: false,
 		showMonthAfterYear: false,
 		yearSuffix: ''};
-	$.datepicker.setDefaults($.datepicker.regional['en-GB']);
-});
+
 /* English/New Zealand initialisation for the jQuery UI date picker plugin. */
 /* Based on the en-GB initialisation. */
-jQuery(function($){
 	$.datepicker.regional['en-NZ'] = {
 		closeText: 'Done',
 		prevText: 'Prev',
@@ -314,11 +292,9 @@ jQuery(function($){
 		isRTL: false,
 		showMonthAfterYear: false,
 		yearSuffix: ''};
-	$.datepicker.setDefaults($.datepicker.regional['en-NZ']);
-});
+
 /* Esperanto initialisation for the jQuery UI date picker plugin. */
 /* Written by Olivier M. (olivierweb@ifrance.com). */
-jQuery(function($){
 	$.datepicker.regional['eo'] = {
 		closeText: 'Fermi',
 		prevText: '&lt;Anta',
@@ -337,11 +313,9 @@ jQuery(function($){
 		isRTL: false,
 		showMonthAfterYear: false,
 		yearSuffix: ''};
-	$.datepicker.setDefaults($.datepicker.regional['eo']);
-});
+
 /* Inicialización en español para la extensión 'UI date picker' para jQuery. */
 /* Traducido por Vester (xvester@gmail.com). */
-jQuery(function($){
 	$.datepicker.regional['es'] = {
 		closeText: 'Cerrar',
 		prevText: '&#x3c;Ant',
@@ -360,10 +334,10 @@ jQuery(function($){
 		isRTL: false,
 		showMonthAfterYear: false,
 		yearSuffix: ''};
-	$.datepicker.setDefaults($.datepicker.regional['es']);
-});/* Estonian initialisation for the jQuery UI date picker plugin. */
+
+
+/* Estonian initialisation for the jQuery UI date picker plugin. */
 /* Written by Mart Sõmermaa (mrts.pydev at gmail com). */
-jQuery(function($){
 	$.datepicker.regional['et'] = {
 		closeText: 'Sulge',
 		prevText: 'Eelnev',
@@ -382,10 +356,9 @@ jQuery(function($){
 		isRTL: false,
 		showMonthAfterYear: false,
 		yearSuffix: ''};
-	$.datepicker.setDefaults($.datepicker.regional['et']);
-}); /* Euskarako oinarria 'UI date picker' jquery-ko extentsioarentzat */
+
+/* Euskarako oinarria 'UI date picker' jquery-ko extentsioarentzat */
 /* Karrikas-ek itzulia (karrikas@karrikas.com) */
-jQuery(function($){
 	$.datepicker.regional['eu'] = {
 		closeText: 'Egina',
 		prevText: '&#x3c;Aur',
@@ -404,11 +377,10 @@ jQuery(function($){
 		isRTL: false,
 		showMonthAfterYear: false,
 		yearSuffix: ''};
-	$.datepicker.setDefaults($.datepicker.regional['eu']);
-});/* Persian (Farsi) Translation for the jQuery UI date picker plugin. */
+
+/* Persian (Farsi) Translation for the jQuery UI date picker plugin. */
 /* Javad Mowlanezhad -- jmowla@gmail.com */
 /* Jalali calendar should supported soon! (Its implemented but I have to test it) */
-jQuery(function($) {
 	$.datepicker.regional['fa'] = {
 		closeText: 'بستن',
 		prevText: '&#x3c;قبلي',
@@ -426,10 +398,9 @@ jQuery(function($) {
 		isRTL: true,
 		showMonthAfterYear: false,
 		yearSuffix: ''};
-	$.datepicker.setDefaults($.datepicker.regional['fa']);
-});/* Finnish initialisation for the jQuery UI date picker plugin. */
+
+/* Finnish initialisation for the jQuery UI date picker plugin. */
 /* Written by Harri Kilpi� (harrikilpio@gmail.com). */
-jQuery(function($){
     $.datepicker.regional['fi'] = {
 		closeText: 'Sulje',
 		prevText: '&laquo;Edellinen',
@@ -448,11 +419,9 @@ jQuery(function($){
 		isRTL: false,
 		showMonthAfterYear: false,
 		yearSuffix: ''};
-    $.datepicker.setDefaults($.datepicker.regional['fi']);
-});
+
 /* Faroese initialisation for the jQuery UI date picker plugin */
 /* Written by Sverri Mohr Olsen, sverrimo@gmail.com */
-jQuery(function($){
 	$.datepicker.regional['fo'] = {
 		closeText: 'Lat aftur',
 		prevText: '&#x3c;Fyrra',
@@ -471,11 +440,9 @@ jQuery(function($){
 		isRTL: false,
 		showMonthAfterYear: false,
 		yearSuffix: ''};
-	$.datepicker.setDefaults($.datepicker.regional['fo']);
-});
+
 /* Swiss-French initialisation for the jQuery UI date picker plugin. */
 /* Written Martin Voelkle (martin.voelkle@e-tc.ch). */
-jQuery(function($){
 	$.datepicker.regional['fr-CH'] = {
 		closeText: 'Fermer',
 		prevText: '&#x3c;Préc',
@@ -494,12 +461,11 @@ jQuery(function($){
 		isRTL: false,
 		showMonthAfterYear: false,
 		yearSuffix: ''};
-	$.datepicker.setDefaults($.datepicker.regional['fr-CH']);
-});/* French initialisation for the jQuery UI date picker plugin. */
+
+/* French initialisation for the jQuery UI date picker plugin. */
 /* Written by Keith Wood (kbwood{at}iinet.com.au),
               Stéphane Nahmani (sholby@sholby.net),
               Stéphane Raimbault <stephane.raimbault@gmail.com> */
-jQuery(function($){
 	$.datepicker.regional['fr'] = {
 		closeText: 'Fermer',
 		prevText: 'Précédent',
@@ -518,11 +484,9 @@ jQuery(function($){
 		isRTL: false,
 		showMonthAfterYear: false,
 		yearSuffix: ''};
-	$.datepicker.setDefaults($.datepicker.regional['fr']);
-});
+
 /* Galician localization for 'UI date picker' jQuery extension. */
 /* Translated by Jorge Barreiro <yortx.barry@gmail.com>. */
-jQuery(function($){
 	$.datepicker.regional['gl'] = {
 		closeText: 'Pechar',
 		prevText: '&#x3c;Ant',
@@ -541,10 +505,9 @@ jQuery(function($){
 		isRTL: false,
 		showMonthAfterYear: false,
 		yearSuffix: ''};
-	$.datepicker.setDefaults($.datepicker.regional['gl']);
-});/* Hebrew initialisation for the UI Datepicker extension. */
+
+/* Hebrew initialisation for the UI Datepicker extension. */
 /* Written by Amir Hardon (ahardon at gmail dot com). */
-jQuery(function($){
 	$.datepicker.regional['he'] = {
 		closeText: 'סגור',
 		prevText: '&#x3c;הקודם',
@@ -563,11 +526,9 @@ jQuery(function($){
 		isRTL: true,
 		showMonthAfterYear: false,
 		yearSuffix: ''};
-	$.datepicker.setDefaults($.datepicker.regional['he']);
-});
+
 /* Croatian i18n for the jQuery UI date picker plugin. */
 /* Written by Vjekoslav Nesek. */
-jQuery(function($){
 	$.datepicker.regional['hr'] = {
 		closeText: 'Zatvori',
 		prevText: '&#x3c;',
@@ -586,10 +547,9 @@ jQuery(function($){
 		isRTL: false,
 		showMonthAfterYear: false,
 		yearSuffix: ''};
-	$.datepicker.setDefaults($.datepicker.regional['hr']);
-});/* Hungarian initialisation for the jQuery UI date picker plugin. */
+
+/* Hungarian initialisation for the jQuery UI date picker plugin. */
 /* Written by Istvan Karaszi (jquery@spam.raszi.hu). */
-jQuery(function($){
 	$.datepicker.regional['hu'] = {
 		closeText: 'bezárás',
 		prevText: '&laquo;&nbsp;vissza',
@@ -608,11 +568,9 @@ jQuery(function($){
 		isRTL: false,
 		showMonthAfterYear: true,
 		yearSuffix: ''};
-	$.datepicker.setDefaults($.datepicker.regional['hu']);
-});
+
 /* Armenian(UTF-8) initialisation for the jQuery UI date picker plugin. */
 /* Written by Levon Zakaryan (levon.zakaryan@gmail.com)*/
-jQuery(function($){
 	$.datepicker.regional['hy'] = {
 		closeText: 'Փակել',
 		prevText: '&#x3c;Նախ.',
@@ -631,10 +589,9 @@ jQuery(function($){
 		isRTL: false,
 		showMonthAfterYear: false,
 		yearSuffix: ''};
-	$.datepicker.setDefaults($.datepicker.regional['hy']);
-});/* Indonesian initialisation for the jQuery UI date picker plugin. */
+
+/* Indonesian initialisation for the jQuery UI date picker plugin. */
 /* Written by Deden Fathurahman (dedenf@gmail.com). */
-jQuery(function($){
 	$.datepicker.regional['id'] = {
 		closeText: 'Tutup',
 		prevText: '&#x3c;mundur',
@@ -653,10 +610,9 @@ jQuery(function($){
 		isRTL: false,
 		showMonthAfterYear: false,
 		yearSuffix: ''};
-	$.datepicker.setDefaults($.datepicker.regional['id']);
-});/* Icelandic initialisation for the jQuery UI date picker plugin. */
+
+/* Icelandic initialisation for the jQuery UI date picker plugin. */
 /* Written by Haukur H. Thorsson (haukur@eskill.is). */
-jQuery(function($){
 	$.datepicker.regional['is'] = {
 		closeText: 'Loka',
 		prevText: '&#x3c; Fyrri',
@@ -675,10 +631,9 @@ jQuery(function($){
 		isRTL: false,
 		showMonthAfterYear: false,
 		yearSuffix: ''};
-	$.datepicker.setDefaults($.datepicker.regional['is']);
-});/* Italian initialisation for the jQuery UI date picker plugin. */
+
+/* Italian initialisation for the jQuery UI date picker plugin. */
 /* Written by Antonello Pasella (antonello.pasella@gmail.com). */
-jQuery(function($){
 	$.datepicker.regional['it'] = {
 		closeText: 'Chiudi',
 		prevText: '&#x3c;Prec',
@@ -697,11 +652,9 @@ jQuery(function($){
 		isRTL: false,
 		showMonthAfterYear: false,
 		yearSuffix: ''};
-	$.datepicker.setDefaults($.datepicker.regional['it']);
-});
+
 /* Japanese initialisation for the jQuery UI date picker plugin. */
 /* Written by Kentaro SATO (kentaro@ranvis.com). */
-jQuery(function($){
 	$.datepicker.regional['ja'] = {
 		closeText: '閉じる',
 		prevText: '&#x3c;前',
@@ -720,10 +673,9 @@ jQuery(function($){
 		isRTL: false,
 		showMonthAfterYear: true,
 		yearSuffix: '年'};
-	$.datepicker.setDefaults($.datepicker.regional['ja']);
-});/* Korean initialisation for the jQuery calendar extension. */
+
+/* Korean initialisation for the jQuery calendar extension. */
 /* Written by DaeKwon Kang (ncrash.dk@gmail.com). */
-jQuery(function($){
 	$.datepicker.regional['ko'] = {
 		closeText: '닫기',
 		prevText: '이전달',
@@ -742,10 +694,9 @@ jQuery(function($){
 		isRTL: false,
 		showMonthAfterYear: false,
 		yearSuffix: '년'};
-	$.datepicker.setDefaults($.datepicker.regional['ko']);
-});/* Kazakh (UTF-8) initialisation for the jQuery UI date picker plugin. */
+
+/* Kazakh (UTF-8) initialisation for the jQuery UI date picker plugin. */
 /* Written by Dmitriy Karasyov (dmitriy.karasyov@gmail.com). */
-jQuery(function($){
 	$.datepicker.regional['kz'] = {
 		closeText: 'Жабу',
 		prevText: '&#x3c;Алдыңғы',
@@ -764,11 +715,9 @@ jQuery(function($){
 		isRTL: false,
 		showMonthAfterYear: false,
 		yearSuffix: ''};
-	$.datepicker.setDefaults($.datepicker.regional['kz']);
-});
+
 /* Lithuanian (UTF-8) initialisation for the jQuery UI date picker plugin. */
 /* @author Arturas Paleicikas <arturas@avalon.lt> */
-jQuery(function($){
 	$.datepicker.regional['lt'] = {
 		closeText: 'Uždaryti',
 		prevText: '&#x3c;Atgal',
@@ -787,10 +736,9 @@ jQuery(function($){
 		isRTL: false,
 		showMonthAfterYear: false,
 		yearSuffix: ''};
-	$.datepicker.setDefaults($.datepicker.regional['lt']);
-});/* Latvian (UTF-8) initialisation for the jQuery UI date picker plugin. */
+
+/* Latvian (UTF-8) initialisation for the jQuery UI date picker plugin. */
 /* @author Arturas Paleicikas <arturas.paleicikas@metasite.net> */
-jQuery(function($){
 	$.datepicker.regional['lv'] = {
 		closeText: 'Aizvērt',
 		prevText: 'Iepr',
@@ -809,10 +757,9 @@ jQuery(function($){
 		isRTL: false,
 		showMonthAfterYear: false,
 		yearSuffix: ''};
-	$.datepicker.setDefaults($.datepicker.regional['lv']);
-});/* Malayalam (UTF-8) initialisation for the jQuery UI date picker plugin. */
+
+/* Malayalam (UTF-8) initialisation for the jQuery UI date picker plugin. */
 /* Written by Saji Nediyanchath (saji89@gmail.com). */
-jQuery(function($){
 	$.datepicker.regional['ml'] = {
 		closeText: 'ശരി',
 		prevText: 'മുന്നത്തെ',  
@@ -831,11 +778,9 @@ jQuery(function($){
 		isRTL: false,
 		showMonthAfterYear: false,
 		yearSuffix: ''};
-	$.datepicker.setDefaults($.datepicker.regional['ml']);
-});
+
 /* Malaysian initialisation for the jQuery UI date picker plugin. */
 /* Written by Mohd Nawawi Mohamad Jamili (nawawi@ronggeng.net). */
-jQuery(function($){
 	$.datepicker.regional['ms'] = {
 		closeText: 'Tutup',
 		prevText: '&#x3c;Sebelum',
@@ -854,10 +799,9 @@ jQuery(function($){
 		isRTL: false,
 		showMonthAfterYear: false,
 		yearSuffix: ''};
-	$.datepicker.setDefaults($.datepicker.regional['ms']);
-});/* Dutch (UTF-8) initialisation for the jQuery UI date picker plugin. */
+
+/* Dutch (UTF-8) initialisation for the jQuery UI date picker plugin. */
 /* Written by Mathias Bynens <http://mathiasbynens.be/> */
-jQuery(function($){
 	$.datepicker.regional.nl = {
 		closeText: 'Sluiten',
 		prevText: '←',
@@ -876,11 +820,9 @@ jQuery(function($){
 		isRTL: false,
 		showMonthAfterYear: false,
 		yearSuffix: ''};
-	$.datepicker.setDefaults($.datepicker.regional.nl);
-});/* Norwegian initialisation for the jQuery UI date picker plugin. */
-/* Written by Naimdjon Takhirov (naimdjon@gmail.com). */
 
-jQuery(function($){
+/* Norwegian initialisation for the jQuery UI date picker plugin. */
+/* Written by Naimdjon Takhirov (naimdjon@gmail.com). */
   $.datepicker.regional['no'] = {
     closeText: 'Lukk',
     prevText: '&laquo;Forrige',
@@ -898,11 +840,8 @@ jQuery(function($){
     showMonthAfterYear: false,
     yearSuffix: ''
   };
-  $.datepicker.setDefaults($.datepicker.regional['no']);
-});
 /* Polish initialisation for the jQuery UI date picker plugin. */
 /* Written by Jacek Wysocki (jacek.wysocki@gmail.com). */
-jQuery(function($){
 	$.datepicker.regional['pl'] = {
 		closeText: 'Zamknij',
 		prevText: '&#x3c;Poprzedni',
@@ -921,11 +860,8 @@ jQuery(function($){
 		isRTL: false,
 		showMonthAfterYear: false,
 		yearSuffix: ''};
-	$.datepicker.setDefaults($.datepicker.regional['pl']);
-});
 /* Brazilian initialisation for the jQuery UI date picker plugin. */
 /* Written by Leonildo Costa Silva (leocsilva@gmail.com). */
-jQuery(function($){
 	$.datepicker.regional['pt-BR'] = {
 		closeText: 'Fechar',
 		prevText: '&#x3c;Anterior',
@@ -944,9 +880,8 @@ jQuery(function($){
 		isRTL: false,
 		showMonthAfterYear: false,
 		yearSuffix: ''};
-	$.datepicker.setDefaults($.datepicker.regional['pt-BR']);
-});/* Portuguese initialisation for the jQuery UI date picker plugin. */
-jQuery(function($){
+
+/* Portuguese initialisation for the jQuery UI date picker plugin. */
 	$.datepicker.regional['pt'] = {
 		closeText: 'Fechar',
 		prevText: '&#x3c;Anterior',
@@ -965,10 +900,9 @@ jQuery(function($){
 		isRTL: false,
 		showMonthAfterYear: false,
 		yearSuffix: ''};
-	$.datepicker.setDefaults($.datepicker.regional['pt']);
-});/* Romansh initialisation for the jQuery UI date picker plugin. */
+
+/* Romansh initialisation for the jQuery UI date picker plugin. */
 /* Written by Yvonne Gienal (yvonne.gienal@educa.ch). */
-jQuery(function($){
 	$.datepicker.regional['rm'] = {
 		closeText: 'Serrar',
 		prevText: '&#x3c;Suandant',
@@ -985,14 +919,12 @@ jQuery(function($){
 		isRTL: false,
 		showMonthAfterYear: false,
 		yearSuffix: ''};
-	$.datepicker.setDefaults($.datepicker.regional['rm']);
-});
+
 /* Romanian initialisation for the jQuery UI date picker plugin.
  *
  * Written by Edmond L. (ll_edmond@walla.com)
  * and Ionut G. Stan (ionut.g.stan@gmail.com)
  */
-jQuery(function($){
 	$.datepicker.regional['ro'] = {
 		closeText: 'Închide',
 		prevText: '&laquo; Luna precedentă',
@@ -1011,11 +943,9 @@ jQuery(function($){
 		isRTL: false,
 		showMonthAfterYear: false,
 		yearSuffix: ''};
-	$.datepicker.setDefaults($.datepicker.regional['ro']);
-});
+
 /* Russian (UTF-8) initialisation for the jQuery UI date picker plugin. */
 /* Written by Andrew Stromnov (stromnov@gmail.com). */
-jQuery(function($){
 	$.datepicker.regional['ru'] = {
 		closeText: 'Закрыть',
 		prevText: '&#x3c;Пред',
@@ -1034,10 +964,9 @@ jQuery(function($){
 		isRTL: false,
 		showMonthAfterYear: false,
 		yearSuffix: ''};
-	$.datepicker.setDefaults($.datepicker.regional['ru']);
-});/* Slovak initialisation for the jQuery UI date picker plugin. */
+
+/* Slovak initialisation for the jQuery UI date picker plugin. */
 /* Written by Vojtech Rinik (vojto@hmm.sk). */
-jQuery(function($){
 	$.datepicker.regional['sk'] = {
 		closeText: 'Zavrieť',
 		prevText: '&#x3c;Predchádzajúci',
@@ -1056,12 +985,10 @@ jQuery(function($){
 		isRTL: false,
 		showMonthAfterYear: false,
 		yearSuffix: ''};
-	$.datepicker.setDefaults($.datepicker.regional['sk']);
-});
+
 /* Slovenian initialisation for the jQuery UI date picker plugin. */
 /* Written by Jaka Jancar (jaka@kubje.org). */
 /* c = &#x10D;, s = &#x161; z = &#x17E; C = &#x10C; S = &#x160; Z = &#x17D; */
-jQuery(function($){
 	$.datepicker.regional['sl'] = {
 		closeText: 'Zapri',
 		prevText: '&lt;Prej&#x161;nji',
@@ -1080,11 +1007,9 @@ jQuery(function($){
 		isRTL: false,
 		showMonthAfterYear: false,
 		yearSuffix: ''};
-	$.datepicker.setDefaults($.datepicker.regional['sl']);
-});
+
 /* Albanian initialisation for the jQuery UI date picker plugin. */
 /* Written by Flakron Bytyqi (flakron@gmail.com). */
-jQuery(function($){
 	$.datepicker.regional['sq'] = {
 		closeText: 'mbylle',
 		prevText: '&#x3c;mbrapa',
@@ -1103,11 +1028,9 @@ jQuery(function($){
 		isRTL: false,
 		showMonthAfterYear: false,
 		yearSuffix: ''};
-	$.datepicker.setDefaults($.datepicker.regional['sq']);
-});
+
 /* Serbian i18n for the jQuery UI date picker plugin. */
 /* Written by Dejan Dimić. */
-jQuery(function($){
 	$.datepicker.regional['sr-SR'] = {
 		closeText: 'Zatvori',
 		prevText: '&#x3c;',
@@ -1126,11 +1049,9 @@ jQuery(function($){
 		isRTL: false,
 		showMonthAfterYear: false,
 		yearSuffix: ''};
-	$.datepicker.setDefaults($.datepicker.regional['sr-SR']);
-});
+
 /* Serbian i18n for the jQuery UI date picker plugin. */
 /* Written by Dejan Dimić. */
-jQuery(function($){
 	$.datepicker.regional['sr'] = {
 		closeText: 'Затвори',
 		prevText: '&#x3c;',
@@ -1149,11 +1070,9 @@ jQuery(function($){
 		isRTL: false,
 		showMonthAfterYear: false,
 		yearSuffix: ''};
-	$.datepicker.setDefaults($.datepicker.regional['sr']);
-});
+
 /* Swedish initialisation for the jQuery UI date picker plugin. */
 /* Written by Anders Ekdahl ( anders@nomadiz.se). */
-jQuery(function($){
     $.datepicker.regional['sv'] = {
 		closeText: 'Stäng',
         prevText: '&laquo;Förra',
@@ -1172,11 +1091,9 @@ jQuery(function($){
 		isRTL: false,
 		showMonthAfterYear: false,
 		yearSuffix: ''};
-    $.datepicker.setDefaults($.datepicker.regional['sv']);
-});
+
 /* Tamil (UTF-8) initialisation for the jQuery UI date picker plugin. */
 /* Written by S A Sureshkumar (saskumar@live.com). */
-jQuery(function($){
 	$.datepicker.regional['ta'] = {
 		closeText: 'மூடு',
 		prevText: 'முன்னையது',
@@ -1195,11 +1112,9 @@ jQuery(function($){
 		isRTL: false,
 		showMonthAfterYear: false,
 		yearSuffix: ''};
-	$.datepicker.setDefaults($.datepicker.regional['ta']);
-});
+
 /* Thai initialisation for the jQuery UI date picker plugin. */
 /* Written by pipo (pipo@sixhead.com). */
-jQuery(function($){
 	$.datepicker.regional['th'] = {
 		closeText: 'ปิด',
 		prevText: '&laquo;&nbsp;ย้อน',
@@ -1218,10 +1133,9 @@ jQuery(function($){
 		isRTL: false,
 		showMonthAfterYear: false,
 		yearSuffix: ''};
-	$.datepicker.setDefaults($.datepicker.regional['th']);
-});/* Tajiki (UTF-8) initialisation for the jQuery UI date picker plugin. */
+
+/* Tajiki (UTF-8) initialisation for the jQuery UI date picker plugin. */
 /* Written by Abdurahmon Saidov (saidovab@gmail.com). */
-jQuery(function($){
 	$.datepicker.regional['tj'] = {
 		closeText: 'Идома',
 		prevText: '&#x3c;Қафо',
@@ -1240,10 +1154,9 @@ jQuery(function($){
 		isRTL: false,
 		showMonthAfterYear: false,
 		yearSuffix: ''};
-	$.datepicker.setDefaults($.datepicker.regional['tj']);
-});/* Turkish initialisation for the jQuery UI date picker plugin. */
+
+/* Turkish initialisation for the jQuery UI date picker plugin. */
 /* Written by Izzet Emre Erkan (kara@karalamalar.net). */
-jQuery(function($){
 	$.datepicker.regional['tr'] = {
 		closeText: 'kapat',
 		prevText: '&#x3c;geri',
@@ -1262,10 +1175,9 @@ jQuery(function($){
 		isRTL: false,
 		showMonthAfterYear: false,
 		yearSuffix: ''};
-	$.datepicker.setDefaults($.datepicker.regional['tr']);
-});/* Ukrainian (UTF-8) initialisation for the jQuery UI date picker plugin. */
+
+/* Ukrainian (UTF-8) initialisation for the jQuery UI date picker plugin. */
 /* Written by Maxim Drogobitskiy (maxdao@gmail.com). */
-jQuery(function($){
 	$.datepicker.regional['uk'] = {
 		closeText: 'Закрити',
 		prevText: '&#x3c;',
@@ -1284,10 +1196,9 @@ jQuery(function($){
 		isRTL: false,
 		showMonthAfterYear: false,
 		yearSuffix: ''};
-	$.datepicker.setDefaults($.datepicker.regional['uk']);
-});/* Vietnamese initialisation for the jQuery UI date picker plugin. */
+
+/* Vietnamese initialisation for the jQuery UI date picker plugin. */
 /* Translated by Le Thanh Huy (lthanhhuy@cit.ctu.edu.vn). */
-jQuery(function($){
 	$.datepicker.regional['vi'] = {
 		closeText: 'Đóng',
 		prevText: '&#x3c;Trước',
@@ -1306,11 +1217,9 @@ jQuery(function($){
 		isRTL: false,
 		showMonthAfterYear: false,
 		yearSuffix: ''};
-	$.datepicker.setDefaults($.datepicker.regional['vi']);
-});
+
 /* Chinese initialisation for the jQuery UI date picker plugin. */
 /* Written by Cloudream (cloudream@gmail.com). */
-jQuery(function($){
 	$.datepicker.regional['zh-CN'] = {
 		closeText: '关闭',
 		prevText: '&#x3c;上月',
@@ -1329,11 +1238,9 @@ jQuery(function($){
 		isRTL: false,
 		showMonthAfterYear: true,
 		yearSuffix: '年'};
-	$.datepicker.setDefaults($.datepicker.regional['zh-CN']);
-});
+
 /* Chinese initialisation for the jQuery UI date picker plugin. */
 /* Written by SCCY (samuelcychan@gmail.com). */
-jQuery(function($){
 	$.datepicker.regional['zh-HK'] = {
 		closeText: '關閉',
 		prevText: '&#x3c;上月',
@@ -1352,11 +1259,9 @@ jQuery(function($){
 		isRTL: false,
 		showMonthAfterYear: true,
 		yearSuffix: '年'};
-	$.datepicker.setDefaults($.datepicker.regional['zh-HK']);
-});
+
 /* Chinese initialisation for the jQuery UI date picker plugin. */
 /* Written by Ressol (ressol@gmail.com). */
-jQuery(function($){
 	$.datepicker.regional['zh-TW'] = {
 		closeText: '關閉',
 		prevText: '&#x3c;上月',
@@ -1375,5 +1280,6 @@ jQuery(function($){
 		isRTL: false,
 		showMonthAfterYear: true,
 		yearSuffix: '年'};
-	$.datepicker.setDefaults($.datepicker.regional['zh-TW']);
+
+$.datepicker.setDefaults($.datepicker.regional['en-GB']);
 });

--- a/Resources/public/jquery-ui-i18n.js
+++ b/Resources/public/jquery-ui-i18n.js
@@ -1,1285 +1,1285 @@
 /* Afrikaans initialisation for the jQuery UI date picker plugin. */
 /* Written by Renier Pretorius. */
-jQuery(function($){
-	$.datepicker.regional['af'] = {
-		closeText: 'Selekteer',
-		prevText: 'Vorige',
-		nextText: 'Volgende',
-		currentText: 'Vandag',
-		monthNames: ['Januarie','Februarie','Maart','April','Mei','Junie',
-		'Julie','Augustus','September','Oktober','November','Desember'],
-		monthNamesShort: ['Jan', 'Feb', 'Mrt', 'Apr', 'Mei', 'Jun',
-		'Jul', 'Aug', 'Sep', 'Okt', 'Nov', 'Des'],
-		dayNames: ['Sondag', 'Maandag', 'Dinsdag', 'Woensdag', 'Donderdag', 'Vrydag', 'Saterdag'],
-		dayNamesShort: ['Son', 'Maa', 'Din', 'Woe', 'Don', 'Vry', 'Sat'],
-		dayNamesMin: ['So','Ma','Di','Wo','Do','Vr','Sa'],
-		weekHeader: 'Wk',
-		dateFormat: 'dd/mm/yy',
-		firstDay: 1,
-		isRTL: false,
-		showMonthAfterYear: false,
-		yearSuffix: ''};
+jQuery(function ($) {
+    $.datepicker.regional['af'] = {
+        closeText:'Selekteer',
+        prevText:'Vorige',
+        nextText:'Volgende',
+        currentText:'Vandag',
+        monthNames:['Januarie', 'Februarie', 'Maart', 'April', 'Mei', 'Junie',
+            'Julie', 'Augustus', 'September', 'Oktober', 'November', 'Desember'],
+        monthNamesShort:['Jan', 'Feb', 'Mrt', 'Apr', 'Mei', 'Jun',
+            'Jul', 'Aug', 'Sep', 'Okt', 'Nov', 'Des'],
+        dayNames:['Sondag', 'Maandag', 'Dinsdag', 'Woensdag', 'Donderdag', 'Vrydag', 'Saterdag'],
+        dayNamesShort:['Son', 'Maa', 'Din', 'Woe', 'Don', 'Vry', 'Sat'],
+        dayNamesMin:['So', 'Ma', 'Di', 'Wo', 'Do', 'Vr', 'Sa'],
+        weekHeader:'Wk',
+        dateFormat:'dd/mm/yy',
+        firstDay:1,
+        isRTL:false,
+        showMonthAfterYear:false,
+        yearSuffix:''};
 
-/* Algerian Arabic Translation for jQuery UI date picker plugin. (can be used for Tunisia)*/
-/* Mohamed Cherif BOUCHELAGHEM -- cherifbouchelaghem@yahoo.fr */
-	$.datepicker.regional['ar-DZ'] = {
-		closeText: 'إغلاق',
-		prevText: '&#x3c;السابق',
-		nextText: 'التالي&#x3e;',
-		currentText: 'اليوم',
-		monthNames: ['جانفي', 'فيفري', 'مارس', 'أفريل', 'ماي', 'جوان',
-		'جويلية', 'أوت', 'سبتمبر','أكتوبر', 'نوفمبر', 'ديسمبر'],
-		monthNamesShort: ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12'],
-		dayNames: ['الأحد', 'الاثنين', 'الثلاثاء', 'الأربعاء', 'الخميس', 'الجمعة', 'السبت'],
-		dayNamesShort: ['الأحد', 'الاثنين', 'الثلاثاء', 'الأربعاء', 'الخميس', 'الجمعة', 'السبت'],
-		dayNamesMin: ['الأحد', 'الاثنين', 'الثلاثاء', 'الأربعاء', 'الخميس', 'الجمعة', 'السبت'],
-		weekHeader: 'أسبوع',
-		dateFormat: 'dd/mm/yy',
-		firstDay: 6,
-  		isRTL: true,
-		showMonthAfterYear: false,
-		yearSuffix: ''};
+    /* Algerian Arabic Translation for jQuery UI date picker plugin. (can be used for Tunisia)*/
+    /* Mohamed Cherif BOUCHELAGHEM -- cherifbouchelaghem@yahoo.fr */
+    $.datepicker.regional['ar-DZ'] = {
+        closeText:'إغلاق',
+        prevText:'&#x3c;السابق',
+        nextText:'التالي&#x3e;',
+        currentText:'اليوم',
+        monthNames:['جانفي', 'فيفري', 'مارس', 'أفريل', 'ماي', 'جوان',
+            'جويلية', 'أوت', 'سبتمبر', 'أكتوبر', 'نوفمبر', 'ديسمبر'],
+        monthNamesShort:['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12'],
+        dayNames:['الأحد', 'الاثنين', 'الثلاثاء', 'الأربعاء', 'الخميس', 'الجمعة', 'السبت'],
+        dayNamesShort:['الأحد', 'الاثنين', 'الثلاثاء', 'الأربعاء', 'الخميس', 'الجمعة', 'السبت'],
+        dayNamesMin:['الأحد', 'الاثنين', 'الثلاثاء', 'الأربعاء', 'الخميس', 'الجمعة', 'السبت'],
+        weekHeader:'أسبوع',
+        dateFormat:'dd/mm/yy',
+        firstDay:6,
+        isRTL:true,
+        showMonthAfterYear:false,
+        yearSuffix:''};
 
-/* Arabic Translation for jQuery UI date picker plugin. */
-/* Khaled Alhourani -- me@khaledalhourani.com */
-/* NOTE: monthNames are the original months names and they are the Arabic names, not the new months name فبراير - يناير and there isn't any Arabic roots for these months */
-	$.datepicker.regional['ar'] = {
-		closeText: 'إغلاق',
-		prevText: '&#x3c;السابق',
-		nextText: 'التالي&#x3e;',
-		currentText: 'اليوم',
-		monthNames: ['كانون الثاني', 'شباط', 'آذار', 'نيسان', 'مايو', 'حزيران',
-		'تموز', 'آب', 'أيلول',	'تشرين الأول', 'تشرين الثاني', 'كانون الأول'],
-		monthNamesShort: ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12'],
-		dayNames: ['الأحد', 'الاثنين', 'الثلاثاء', 'الأربعاء', 'الخميس', 'الجمعة', 'السبت'],
-		dayNamesShort: ['الأحد', 'الاثنين', 'الثلاثاء', 'الأربعاء', 'الخميس', 'الجمعة', 'السبت'],
-		dayNamesMin: ['الأحد', 'الاثنين', 'الثلاثاء', 'الأربعاء', 'الخميس', 'الجمعة', 'السبت'],
-		weekHeader: 'أسبوع',
-		dateFormat: 'dd/mm/yy',
-		firstDay: 6,
-  		isRTL: true,
-		showMonthAfterYear: false,
-		yearSuffix: ''};
+    /* Arabic Translation for jQuery UI date picker plugin. */
+    /* Khaled Alhourani -- me@khaledalhourani.com */
+    /* NOTE: monthNames are the original months names and they are the Arabic names, not the new months name فبراير - يناير and there isn't any Arabic roots for these months */
+    $.datepicker.regional['ar'] = {
+        closeText:'إغلاق',
+        prevText:'&#x3c;السابق',
+        nextText:'التالي&#x3e;',
+        currentText:'اليوم',
+        monthNames:['كانون الثاني', 'شباط', 'آذار', 'نيسان', 'مايو', 'حزيران',
+            'تموز', 'آب', 'أيلول', 'تشرين الأول', 'تشرين الثاني', 'كانون الأول'],
+        monthNamesShort:['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12'],
+        dayNames:['الأحد', 'الاثنين', 'الثلاثاء', 'الأربعاء', 'الخميس', 'الجمعة', 'السبت'],
+        dayNamesShort:['الأحد', 'الاثنين', 'الثلاثاء', 'الأربعاء', 'الخميس', 'الجمعة', 'السبت'],
+        dayNamesMin:['الأحد', 'الاثنين', 'الثلاثاء', 'الأربعاء', 'الخميس', 'الجمعة', 'السبت'],
+        weekHeader:'أسبوع',
+        dateFormat:'dd/mm/yy',
+        firstDay:6,
+        isRTL:true,
+        showMonthAfterYear:false,
+        yearSuffix:''};
 
-/* Azerbaijani (UTF-8) initialisation for the jQuery UI date picker plugin. */
-/* Written by Jamil Najafov (necefov33@gmail.com). */
-	$.datepicker.regional['az'] = {
-		closeText: 'Bağla',
-		prevText: '&#x3c;Geri',
-		nextText: 'İrəli&#x3e;',
-		currentText: 'Bugün',
-		monthNames: ['Yanvar','Fevral','Mart','Aprel','May','İyun',
-		'İyul','Avqust','Sentyabr','Oktyabr','Noyabr','Dekabr'],
-		monthNamesShort: ['Yan','Fev','Mar','Apr','May','İyun',
-		'İyul','Avq','Sen','Okt','Noy','Dek'],
-		dayNames: ['Bazar','Bazar ertəsi','Çərşənbə axşamı','Çərşənbə','Cümə axşamı','Cümə','Şənbə'],
-		dayNamesShort: ['B','Be','Ça','Ç','Ca','C','Ş'],
-		dayNamesMin: ['B','B','Ç','С','Ç','C','Ş'],
-		weekHeader: 'Hf',
-		dateFormat: 'dd.mm.yy',
-		firstDay: 1,
-		isRTL: false,
-		showMonthAfterYear: false,
-		yearSuffix: ''};
+    /* Azerbaijani (UTF-8) initialisation for the jQuery UI date picker plugin. */
+    /* Written by Jamil Najafov (necefov33@gmail.com). */
+    $.datepicker.regional['az'] = {
+        closeText:'Bağla',
+        prevText:'&#x3c;Geri',
+        nextText:'İrəli&#x3e;',
+        currentText:'Bugün',
+        monthNames:['Yanvar', 'Fevral', 'Mart', 'Aprel', 'May', 'İyun',
+            'İyul', 'Avqust', 'Sentyabr', 'Oktyabr', 'Noyabr', 'Dekabr'],
+        monthNamesShort:['Yan', 'Fev', 'Mar', 'Apr', 'May', 'İyun',
+            'İyul', 'Avq', 'Sen', 'Okt', 'Noy', 'Dek'],
+        dayNames:['Bazar', 'Bazar ertəsi', 'Çərşənbə axşamı', 'Çərşənbə', 'Cümə axşamı', 'Cümə', 'Şənbə'],
+        dayNamesShort:['B', 'Be', 'Ça', 'Ç', 'Ca', 'C', 'Ş'],
+        dayNamesMin:['B', 'B', 'Ç', 'С', 'Ç', 'C', 'Ş'],
+        weekHeader:'Hf',
+        dateFormat:'dd.mm.yy',
+        firstDay:1,
+        isRTL:false,
+        showMonthAfterYear:false,
+        yearSuffix:''};
 
-/* Bulgarian initialisation for the jQuery UI date picker plugin. */
-/* Written by Stoyan Kyosev (http://svest.org). */
+    /* Bulgarian initialisation for the jQuery UI date picker plugin. */
+    /* Written by Stoyan Kyosev (http://svest.org). */
     $.datepicker.regional['bg'] = {
-        closeText: 'затвори',
-        prevText: '&#x3c;назад',
-        nextText: 'напред&#x3e;',
-	nextBigText: '&#x3e;&#x3e;',
-        currentText: 'днес',
-        monthNames: ['Януари','Февруари','Март','Април','Май','Юни',
-        'Юли','Август','Септември','Октомври','Ноември','Декември'],
-        monthNamesShort: ['Яну','Фев','Мар','Апр','Май','Юни',
-        'Юли','Авг','Сеп','Окт','Нов','Дек'],
-        dayNames: ['Неделя','Понеделник','Вторник','Сряда','Четвъртък','Петък','Събота'],
-        dayNamesShort: ['Нед','Пон','Вто','Сря','Чет','Пет','Съб'],
-        dayNamesMin: ['Не','По','Вт','Ср','Че','Пе','Съ'],
-	weekHeader: 'Wk',
-        dateFormat: 'dd.mm.yy',
-	firstDay: 1,
-        isRTL: false,
-	showMonthAfterYear: false,
-	yearSuffix: ''};
+        closeText:'затвори',
+        prevText:'&#x3c;назад',
+        nextText:'напред&#x3e;',
+        nextBigText:'&#x3e;&#x3e;',
+        currentText:'днес',
+        monthNames:['Януари', 'Февруари', 'Март', 'Април', 'Май', 'Юни',
+            'Юли', 'Август', 'Септември', 'Октомври', 'Ноември', 'Декември'],
+        monthNamesShort:['Яну', 'Фев', 'Мар', 'Апр', 'Май', 'Юни',
+            'Юли', 'Авг', 'Сеп', 'Окт', 'Нов', 'Дек'],
+        dayNames:['Неделя', 'Понеделник', 'Вторник', 'Сряда', 'Четвъртък', 'Петък', 'Събота'],
+        dayNamesShort:['Нед', 'Пон', 'Вто', 'Сря', 'Чет', 'Пет', 'Съб'],
+        dayNamesMin:['Не', 'По', 'Вт', 'Ср', 'Че', 'Пе', 'Съ'],
+        weekHeader:'Wk',
+        dateFormat:'dd.mm.yy',
+        firstDay:1,
+        isRTL:false,
+        showMonthAfterYear:false,
+        yearSuffix:''};
 
-/* Bosnian i18n for the jQuery UI date picker plugin. */
-/* Written by Kenan Konjo. */
-	$.datepicker.regional['bs'] = {
-		closeText: 'Zatvori', 
-		prevText: '&#x3c;', 
-		nextText: '&#x3e;', 
-		currentText: 'Danas', 
-		monthNames: ['Januar','Februar','Mart','April','Maj','Juni',
-		'Juli','August','Septembar','Oktobar','Novembar','Decembar'],
-		monthNamesShort: ['Jan','Feb','Mar','Apr','Maj','Jun',
-		'Jul','Aug','Sep','Okt','Nov','Dec'],
-		dayNames: ['Nedelja','Ponedeljak','Utorak','Srijeda','Četvrtak','Petak','Subota'],
-		dayNamesShort: ['Ned','Pon','Uto','Sri','Čet','Pet','Sub'],
-		dayNamesMin: ['Ne','Po','Ut','Sr','Če','Pe','Su'],
-		weekHeader: 'Wk',
-		dateFormat: 'dd.mm.yy',
-		firstDay: 1,
-		isRTL: false,
-		showMonthAfterYear: false,
-		yearSuffix: ''};
+    /* Bosnian i18n for the jQuery UI date picker plugin. */
+    /* Written by Kenan Konjo. */
+    $.datepicker.regional['bs'] = {
+        closeText:'Zatvori',
+        prevText:'&#x3c;',
+        nextText:'&#x3e;',
+        currentText:'Danas',
+        monthNames:['Januar', 'Februar', 'Mart', 'April', 'Maj', 'Juni',
+            'Juli', 'August', 'Septembar', 'Oktobar', 'Novembar', 'Decembar'],
+        monthNamesShort:['Jan', 'Feb', 'Mar', 'Apr', 'Maj', 'Jun',
+            'Jul', 'Aug', 'Sep', 'Okt', 'Nov', 'Dec'],
+        dayNames:['Nedelja', 'Ponedeljak', 'Utorak', 'Srijeda', 'Četvrtak', 'Petak', 'Subota'],
+        dayNamesShort:['Ned', 'Pon', 'Uto', 'Sri', 'Čet', 'Pet', 'Sub'],
+        dayNamesMin:['Ne', 'Po', 'Ut', 'Sr', 'Če', 'Pe', 'Su'],
+        weekHeader:'Wk',
+        dateFormat:'dd.mm.yy',
+        firstDay:1,
+        isRTL:false,
+        showMonthAfterYear:false,
+        yearSuffix:''};
 
-/* Inicialització en català per a l'extenció 'calendar' per jQuery. */
-/* Writers: (joan.leon@gmail.com). */
-	$.datepicker.regional['ca'] = {
-		closeText: 'Tancar',
-		prevText: '&#x3c;Ant',
-		nextText: 'Seg&#x3e;',
-		currentText: 'Avui',
-		monthNames: ['Gener','Febrer','Mar&ccedil;','Abril','Maig','Juny',
-		'Juliol','Agost','Setembre','Octubre','Novembre','Desembre'],
-		monthNamesShort: ['Gen','Feb','Mar','Abr','Mai','Jun',
-		'Jul','Ago','Set','Oct','Nov','Des'],
-		dayNames: ['Diumenge','Dilluns','Dimarts','Dimecres','Dijous','Divendres','Dissabte'],
-		dayNamesShort: ['Dug','Dln','Dmt','Dmc','Djs','Dvn','Dsb'],
-		dayNamesMin: ['Dg','Dl','Dt','Dc','Dj','Dv','Ds'],
-		weekHeader: 'Sm',
-		dateFormat: 'dd/mm/yy',
-		firstDay: 1,
-		isRTL: false,
-		showMonthAfterYear: false,
-		yearSuffix: ''};
+    /* Inicialització en català per a l'extenció 'calendar' per jQuery. */
+    /* Writers: (joan.leon@gmail.com). */
+    $.datepicker.regional['ca'] = {
+        closeText:'Tancar',
+        prevText:'&#x3c;Ant',
+        nextText:'Seg&#x3e;',
+        currentText:'Avui',
+        monthNames:['Gener', 'Febrer', 'Mar&ccedil;', 'Abril', 'Maig', 'Juny',
+            'Juliol', 'Agost', 'Setembre', 'Octubre', 'Novembre', 'Desembre'],
+        monthNamesShort:['Gen', 'Feb', 'Mar', 'Abr', 'Mai', 'Jun',
+            'Jul', 'Ago', 'Set', 'Oct', 'Nov', 'Des'],
+        dayNames:['Diumenge', 'Dilluns', 'Dimarts', 'Dimecres', 'Dijous', 'Divendres', 'Dissabte'],
+        dayNamesShort:['Dug', 'Dln', 'Dmt', 'Dmc', 'Djs', 'Dvn', 'Dsb'],
+        dayNamesMin:['Dg', 'Dl', 'Dt', 'Dc', 'Dj', 'Dv', 'Ds'],
+        weekHeader:'Sm',
+        dateFormat:'dd/mm/yy',
+        firstDay:1,
+        isRTL:false,
+        showMonthAfterYear:false,
+        yearSuffix:''};
 
-/* Czech initialisation for the jQuery UI date picker plugin. */
-/* Written by Tomas Muller (tomas@tomas-muller.net). */
-	$.datepicker.regional['cs'] = {
-		closeText: 'Zavřít',
-		prevText: '&#x3c;Dříve',
-		nextText: 'Později&#x3e;',
-		currentText: 'Nyní',
-		monthNames: ['leden','únor','březen','duben','květen','červen',
-        'červenec','srpen','září','říjen','listopad','prosinec'],
-		monthNamesShort: ['led','úno','bře','dub','kvě','čer',
-		'čvc','srp','zář','říj','lis','pro'],
-		dayNames: ['neděle', 'pondělí', 'úterý', 'středa', 'čtvrtek', 'pátek', 'sobota'],
-		dayNamesShort: ['ne', 'po', 'út', 'st', 'čt', 'pá', 'so'],
-		dayNamesMin: ['ne','po','út','st','čt','pá','so'],
-		weekHeader: 'Týd',
-		dateFormat: 'dd.mm.yy',
-		firstDay: 1,
-		isRTL: false,
-		showMonthAfterYear: false,
-		yearSuffix: ''};
+    /* Czech initialisation for the jQuery UI date picker plugin. */
+    /* Written by Tomas Muller (tomas@tomas-muller.net). */
+    $.datepicker.regional['cs'] = {
+        closeText:'Zavřít',
+        prevText:'&#x3c;Dříve',
+        nextText:'Později&#x3e;',
+        currentText:'Nyní',
+        monthNames:['leden', 'únor', 'březen', 'duben', 'květen', 'červen',
+            'červenec', 'srpen', 'září', 'říjen', 'listopad', 'prosinec'],
+        monthNamesShort:['led', 'úno', 'bře', 'dub', 'kvě', 'čer',
+            'čvc', 'srp', 'zář', 'říj', 'lis', 'pro'],
+        dayNames:['neděle', 'pondělí', 'úterý', 'středa', 'čtvrtek', 'pátek', 'sobota'],
+        dayNamesShort:['ne', 'po', 'út', 'st', 'čt', 'pá', 'so'],
+        dayNamesMin:['ne', 'po', 'út', 'st', 'čt', 'pá', 'so'],
+        weekHeader:'Týd',
+        dateFormat:'dd.mm.yy',
+        firstDay:1,
+        isRTL:false,
+        showMonthAfterYear:false,
+        yearSuffix:''};
 
-/* Danish initialisation for the jQuery UI date picker plugin. */
-/* Written by Jan Christensen ( deletestuff@gmail.com). */
+    /* Danish initialisation for the jQuery UI date picker plugin. */
+    /* Written by Jan Christensen ( deletestuff@gmail.com). */
     $.datepicker.regional['da'] = {
-		closeText: 'Luk',
-        prevText: '&#x3c;Forrige',
-		nextText: 'Næste&#x3e;',
-		currentText: 'Idag',
-        monthNames: ['Januar','Februar','Marts','April','Maj','Juni',
-        'Juli','August','September','Oktober','November','December'],
-        monthNamesShort: ['Jan','Feb','Mar','Apr','Maj','Jun',
-        'Jul','Aug','Sep','Okt','Nov','Dec'],
-		dayNames: ['Søndag','Mandag','Tirsdag','Onsdag','Torsdag','Fredag','Lørdag'],
-		dayNamesShort: ['Søn','Man','Tir','Ons','Tor','Fre','Lør'],
-		dayNamesMin: ['Sø','Ma','Ti','On','To','Fr','Lø'],
-		weekHeader: 'Uge',
-        dateFormat: 'dd-mm-yy',
-		firstDay: 1,
-		isRTL: false,
-		showMonthAfterYear: false,
-		yearSuffix: ''};
+        closeText:'Luk',
+        prevText:'&#x3c;Forrige',
+        nextText:'Næste&#x3e;',
+        currentText:'Idag',
+        monthNames:['Januar', 'Februar', 'Marts', 'April', 'Maj', 'Juni',
+            'Juli', 'August', 'September', 'Oktober', 'November', 'December'],
+        monthNamesShort:['Jan', 'Feb', 'Mar', 'Apr', 'Maj', 'Jun',
+            'Jul', 'Aug', 'Sep', 'Okt', 'Nov', 'Dec'],
+        dayNames:['Søndag', 'Mandag', 'Tirsdag', 'Onsdag', 'Torsdag', 'Fredag', 'Lørdag'],
+        dayNamesShort:['Søn', 'Man', 'Tir', 'Ons', 'Tor', 'Fre', 'Lør'],
+        dayNamesMin:['Sø', 'Ma', 'Ti', 'On', 'To', 'Fr', 'Lø'],
+        weekHeader:'Uge',
+        dateFormat:'dd-mm-yy',
+        firstDay:1,
+        isRTL:false,
+        showMonthAfterYear:false,
+        yearSuffix:''};
 
-/* German initialisation for the jQuery UI date picker plugin. */
-/* Written by Milian Wolff (mail@milianw.de). */
-	$.datepicker.regional['de'] = {
-		closeText: 'schließen',
-		prevText: '&#x3c;zurück',
-		nextText: 'Vor&#x3e;',
-		currentText: 'heute',
-		monthNames: ['Januar','Februar','März','April','Mai','Juni',
-		'Juli','August','September','Oktober','November','Dezember'],
-		monthNamesShort: ['Jan','Feb','Mär','Apr','Mai','Jun',
-		'Jul','Aug','Sep','Okt','Nov','Dez'],
-		dayNames: ['Sonntag','Montag','Dienstag','Mittwoch','Donnerstag','Freitag','Samstag'],
-		dayNamesShort: ['So','Mo','Di','Mi','Do','Fr','Sa'],
-		dayNamesMin: ['So','Mo','Di','Mi','Do','Fr','Sa'],
-		weekHeader: 'Wo',
-		dateFormat: 'dd.mm.yy',
-		firstDay: 1,
-		isRTL: false,
-		showMonthAfterYear: false,
-		yearSuffix: ''};
+    /* German initialisation for the jQuery UI date picker plugin. */
+    /* Written by Milian Wolff (mail@milianw.de). */
+    $.datepicker.regional['de'] = {
+        closeText:'schließen',
+        prevText:'&#x3c;zurück',
+        nextText:'Vor&#x3e;',
+        currentText:'heute',
+        monthNames:['Januar', 'Februar', 'März', 'April', 'Mai', 'Juni',
+            'Juli', 'August', 'September', 'Oktober', 'November', 'Dezember'],
+        monthNamesShort:['Jan', 'Feb', 'Mär', 'Apr', 'Mai', 'Jun',
+            'Jul', 'Aug', 'Sep', 'Okt', 'Nov', 'Dez'],
+        dayNames:['Sonntag', 'Montag', 'Dienstag', 'Mittwoch', 'Donnerstag', 'Freitag', 'Samstag'],
+        dayNamesShort:['So', 'Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa'],
+        dayNamesMin:['So', 'Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa'],
+        weekHeader:'Wo',
+        dateFormat:'dd.mm.yy',
+        firstDay:1,
+        isRTL:false,
+        showMonthAfterYear:false,
+        yearSuffix:''};
 
-/* Greek (el) initialisation for the jQuery UI date picker plugin. */
-/* Written by Alex Cicovic (http://www.alexcicovic.com) */
-	$.datepicker.regional['el'] = {
-		closeText: 'Κλείσιμο',
-		prevText: 'Προηγούμενος',
-		nextText: 'Επόμενος',
-		currentText: 'Τρέχων Μήνας',
-		monthNames: ['Ιανουάριος','Φεβρουάριος','Μάρτιος','Απρίλιος','Μάιος','Ιούνιος',
-		'Ιούλιος','Αύγουστος','Σεπτέμβριος','Οκτώβριος','Νοέμβριος','Δεκέμβριος'],
-		monthNamesShort: ['Ιαν','Φεβ','Μαρ','Απρ','Μαι','Ιουν',
-		'Ιουλ','Αυγ','Σεπ','Οκτ','Νοε','Δεκ'],
-		dayNames: ['Κυριακή','Δευτέρα','Τρίτη','Τετάρτη','Πέμπτη','Παρασκευή','Σάββατο'],
-		dayNamesShort: ['Κυρ','Δευ','Τρι','Τετ','Πεμ','Παρ','Σαβ'],
-		dayNamesMin: ['Κυ','Δε','Τρ','Τε','Πε','Πα','Σα'],
-		weekHeader: 'Εβδ',
-		dateFormat: 'dd/mm/yy',
-		firstDay: 1,
-		isRTL: false,
-		showMonthAfterYear: false,
-		yearSuffix: ''};
+    /* Greek (el) initialisation for the jQuery UI date picker plugin. */
+    /* Written by Alex Cicovic (http://www.alexcicovic.com) */
+    $.datepicker.regional['el'] = {
+        closeText:'Κλείσιμο',
+        prevText:'Προηγούμενος',
+        nextText:'Επόμενος',
+        currentText:'Τρέχων Μήνας',
+        monthNames:['Ιανουάριος', 'Φεβρουάριος', 'Μάρτιος', 'Απρίλιος', 'Μάιος', 'Ιούνιος',
+            'Ιούλιος', 'Αύγουστος', 'Σεπτέμβριος', 'Οκτώβριος', 'Νοέμβριος', 'Δεκέμβριος'],
+        monthNamesShort:['Ιαν', 'Φεβ', 'Μαρ', 'Απρ', 'Μαι', 'Ιουν',
+            'Ιουλ', 'Αυγ', 'Σεπ', 'Οκτ', 'Νοε', 'Δεκ'],
+        dayNames:['Κυριακή', 'Δευτέρα', 'Τρίτη', 'Τετάρτη', 'Πέμπτη', 'Παρασκευή', 'Σάββατο'],
+        dayNamesShort:['Κυρ', 'Δευ', 'Τρι', 'Τετ', 'Πεμ', 'Παρ', 'Σαβ'],
+        dayNamesMin:['Κυ', 'Δε', 'Τρ', 'Τε', 'Πε', 'Πα', 'Σα'],
+        weekHeader:'Εβδ',
+        dateFormat:'dd/mm/yy',
+        firstDay:1,
+        isRTL:false,
+        showMonthAfterYear:false,
+        yearSuffix:''};
 
-/* English/Australia initialisation for the jQuery UI date picker plugin. */
-/* Based on the en-GB initialisation. */
-	$.datepicker.regional['en-AU'] = {
-		closeText: 'Done',
-		prevText: 'Prev',
-		nextText: 'Next',
-		currentText: 'Today',
-		monthNames: ['January','February','March','April','May','June',
-		'July','August','September','October','November','December'],
-		monthNamesShort: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
-		'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
-		dayNames: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
-		dayNamesShort: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
-		dayNamesMin: ['Su','Mo','Tu','We','Th','Fr','Sa'],
-		weekHeader: 'Wk',
-		dateFormat: 'dd/mm/yy',
-		firstDay: 1,
-		isRTL: false,
-		showMonthAfterYear: false,
-		yearSuffix: ''};
+    /* English/Australia initialisation for the jQuery UI date picker plugin. */
+    /* Based on the en-GB initialisation. */
+    $.datepicker.regional['en-AU'] = {
+        closeText:'Done',
+        prevText:'Prev',
+        nextText:'Next',
+        currentText:'Today',
+        monthNames:['January', 'February', 'March', 'April', 'May', 'June',
+            'July', 'August', 'September', 'October', 'November', 'December'],
+        monthNamesShort:['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+            'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
+        dayNames:['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
+        dayNamesShort:['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+        dayNamesMin:['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'],
+        weekHeader:'Wk',
+        dateFormat:'dd/mm/yy',
+        firstDay:1,
+        isRTL:false,
+        showMonthAfterYear:false,
+        yearSuffix:''};
 
-/* English/UK initialisation for the jQuery UI date picker plugin. */
-/* Written by Stuart. */
-	$.datepicker.regional['en-GB'] = {
-		closeText: 'Done',
-		prevText: 'Prev',
-		nextText: 'Next',
-		currentText: 'Today',
-		monthNames: ['January','February','March','April','May','June',
-		'July','August','September','October','November','December'],
-		monthNamesShort: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
-		'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
-		dayNames: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
-		dayNamesShort: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
-		dayNamesMin: ['Su','Mo','Tu','We','Th','Fr','Sa'],
-		weekHeader: 'Wk',
-		dateFormat: 'dd/mm/yy',
-		firstDay: 1,
-		isRTL: false,
-		showMonthAfterYear: false,
-		yearSuffix: ''};
+    /* English/UK initialisation for the jQuery UI date picker plugin. */
+    /* Written by Stuart. */
+    $.datepicker.regional['en-GB'] = {
+        closeText:'Done',
+        prevText:'Prev',
+        nextText:'Next',
+        currentText:'Today',
+        monthNames:['January', 'February', 'March', 'April', 'May', 'June',
+            'July', 'August', 'September', 'October', 'November', 'December'],
+        monthNamesShort:['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+            'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
+        dayNames:['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
+        dayNamesShort:['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+        dayNamesMin:['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'],
+        weekHeader:'Wk',
+        dateFormat:'dd/mm/yy',
+        firstDay:1,
+        isRTL:false,
+        showMonthAfterYear:false,
+        yearSuffix:''};
 
-/* English/New Zealand initialisation for the jQuery UI date picker plugin. */
-/* Based on the en-GB initialisation. */
-	$.datepicker.regional['en-NZ'] = {
-		closeText: 'Done',
-		prevText: 'Prev',
-		nextText: 'Next',
-		currentText: 'Today',
-		monthNames: ['January','February','March','April','May','June',
-		'July','August','September','October','November','December'],
-		monthNamesShort: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
-		'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
-		dayNames: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
-		dayNamesShort: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
-		dayNamesMin: ['Su','Mo','Tu','We','Th','Fr','Sa'],
-		weekHeader: 'Wk',
-		dateFormat: 'dd/mm/yy',
-		firstDay: 1,
-		isRTL: false,
-		showMonthAfterYear: false,
-		yearSuffix: ''};
+    /* English/New Zealand initialisation for the jQuery UI date picker plugin. */
+    /* Based on the en-GB initialisation. */
+    $.datepicker.regional['en-NZ'] = {
+        closeText:'Done',
+        prevText:'Prev',
+        nextText:'Next',
+        currentText:'Today',
+        monthNames:['January', 'February', 'March', 'April', 'May', 'June',
+            'July', 'August', 'September', 'October', 'November', 'December'],
+        monthNamesShort:['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+            'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
+        dayNames:['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
+        dayNamesShort:['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+        dayNamesMin:['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'],
+        weekHeader:'Wk',
+        dateFormat:'dd/mm/yy',
+        firstDay:1,
+        isRTL:false,
+        showMonthAfterYear:false,
+        yearSuffix:''};
 
-/* Esperanto initialisation for the jQuery UI date picker plugin. */
-/* Written by Olivier M. (olivierweb@ifrance.com). */
-	$.datepicker.regional['eo'] = {
-		closeText: 'Fermi',
-		prevText: '&lt;Anta',
-		nextText: 'Sekv&gt;',
-		currentText: 'Nuna',
-		monthNames: ['Januaro','Februaro','Marto','Aprilo','Majo','Junio',
-		'Julio','Aŭgusto','Septembro','Oktobro','Novembro','Decembro'],
-		monthNamesShort: ['Jan','Feb','Mar','Apr','Maj','Jun',
-		'Jul','Aŭg','Sep','Okt','Nov','Dec'],
-		dayNames: ['Dimanĉo','Lundo','Mardo','Merkredo','Ĵaŭdo','Vendredo','Sabato'],
-		dayNamesShort: ['Dim','Lun','Mar','Mer','Ĵaŭ','Ven','Sab'],
-		dayNamesMin: ['Di','Lu','Ma','Me','Ĵa','Ve','Sa'],
-		weekHeader: 'Sb',
-		dateFormat: 'dd/mm/yy',
-		firstDay: 0,
-		isRTL: false,
-		showMonthAfterYear: false,
-		yearSuffix: ''};
+    /* Esperanto initialisation for the jQuery UI date picker plugin. */
+    /* Written by Olivier M. (olivierweb@ifrance.com). */
+    $.datepicker.regional['eo'] = {
+        closeText:'Fermi',
+        prevText:'&lt;Anta',
+        nextText:'Sekv&gt;',
+        currentText:'Nuna',
+        monthNames:['Januaro', 'Februaro', 'Marto', 'Aprilo', 'Majo', 'Junio',
+            'Julio', 'Aŭgusto', 'Septembro', 'Oktobro', 'Novembro', 'Decembro'],
+        monthNamesShort:['Jan', 'Feb', 'Mar', 'Apr', 'Maj', 'Jun',
+            'Jul', 'Aŭg', 'Sep', 'Okt', 'Nov', 'Dec'],
+        dayNames:['Dimanĉo', 'Lundo', 'Mardo', 'Merkredo', 'Ĵaŭdo', 'Vendredo', 'Sabato'],
+        dayNamesShort:['Dim', 'Lun', 'Mar', 'Mer', 'Ĵaŭ', 'Ven', 'Sab'],
+        dayNamesMin:['Di', 'Lu', 'Ma', 'Me', 'Ĵa', 'Ve', 'Sa'],
+        weekHeader:'Sb',
+        dateFormat:'dd/mm/yy',
+        firstDay:0,
+        isRTL:false,
+        showMonthAfterYear:false,
+        yearSuffix:''};
 
-/* Inicialización en español para la extensión 'UI date picker' para jQuery. */
-/* Traducido por Vester (xvester@gmail.com). */
-	$.datepicker.regional['es'] = {
-		closeText: 'Cerrar',
-		prevText: '&#x3c;Ant',
-		nextText: 'Sig&#x3e;',
-		currentText: 'Hoy',
-		monthNames: ['Enero','Febrero','Marzo','Abril','Mayo','Junio',
-		'Julio','Agosto','Septiembre','Octubre','Noviembre','Diciembre'],
-		monthNamesShort: ['Ene','Feb','Mar','Abr','May','Jun',
-		'Jul','Ago','Sep','Oct','Nov','Dic'],
-		dayNames: ['Domingo','Lunes','Martes','Mi&eacute;rcoles','Jueves','Viernes','S&aacute;bado'],
-		dayNamesShort: ['Dom','Lun','Mar','Mi&eacute;','Juv','Vie','S&aacute;b'],
-		dayNamesMin: ['Do','Lu','Ma','Mi','Ju','Vi','S&aacute;'],
-		weekHeader: 'Sm',
-		dateFormat: 'dd/mm/yy',
-		firstDay: 1,
-		isRTL: false,
-		showMonthAfterYear: false,
-		yearSuffix: ''};
+    /* Inicialización en español para la extensión 'UI date picker' para jQuery. */
+    /* Traducido por Vester (xvester@gmail.com). */
+    $.datepicker.regional['es'] = {
+        closeText:'Cerrar',
+        prevText:'&#x3c;Ant',
+        nextText:'Sig&#x3e;',
+        currentText:'Hoy',
+        monthNames:['Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio',
+            'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre'],
+        monthNamesShort:['Ene', 'Feb', 'Mar', 'Abr', 'May', 'Jun',
+            'Jul', 'Ago', 'Sep', 'Oct', 'Nov', 'Dic'],
+        dayNames:['Domingo', 'Lunes', 'Martes', 'Mi&eacute;rcoles', 'Jueves', 'Viernes', 'S&aacute;bado'],
+        dayNamesShort:['Dom', 'Lun', 'Mar', 'Mi&eacute;', 'Juv', 'Vie', 'S&aacute;b'],
+        dayNamesMin:['Do', 'Lu', 'Ma', 'Mi', 'Ju', 'Vi', 'S&aacute;'],
+        weekHeader:'Sm',
+        dateFormat:'dd/mm/yy',
+        firstDay:1,
+        isRTL:false,
+        showMonthAfterYear:false,
+        yearSuffix:''};
 
 
-/* Estonian initialisation for the jQuery UI date picker plugin. */
-/* Written by Mart Sõmermaa (mrts.pydev at gmail com). */
-	$.datepicker.regional['et'] = {
-		closeText: 'Sulge',
-		prevText: 'Eelnev',
-		nextText: 'Järgnev',
-		currentText: 'Täna',
-		monthNames: ['Jaanuar','Veebruar','Märts','Aprill','Mai','Juuni',
-		'Juuli','August','September','Oktoober','November','Detsember'],
-		monthNamesShort: ['Jaan', 'Veebr', 'Märts', 'Apr', 'Mai', 'Juuni',
-		'Juuli', 'Aug', 'Sept', 'Okt', 'Nov', 'Dets'],
-		dayNames: ['Pühapäev', 'Esmaspäev', 'Teisipäev', 'Kolmapäev', 'Neljapäev', 'Reede', 'Laupäev'],
-		dayNamesShort: ['Pühap', 'Esmasp', 'Teisip', 'Kolmap', 'Neljap', 'Reede', 'Laup'],
-		dayNamesMin: ['P','E','T','K','N','R','L'],
-		weekHeader: 'Sm',
-		dateFormat: 'dd.mm.yy',
-		firstDay: 1,
-		isRTL: false,
-		showMonthAfterYear: false,
-		yearSuffix: ''};
+    /* Estonian initialisation for the jQuery UI date picker plugin. */
+    /* Written by Mart Sõmermaa (mrts.pydev at gmail com). */
+    $.datepicker.regional['et'] = {
+        closeText:'Sulge',
+        prevText:'Eelnev',
+        nextText:'Järgnev',
+        currentText:'Täna',
+        monthNames:['Jaanuar', 'Veebruar', 'Märts', 'Aprill', 'Mai', 'Juuni',
+            'Juuli', 'August', 'September', 'Oktoober', 'November', 'Detsember'],
+        monthNamesShort:['Jaan', 'Veebr', 'Märts', 'Apr', 'Mai', 'Juuni',
+            'Juuli', 'Aug', 'Sept', 'Okt', 'Nov', 'Dets'],
+        dayNames:['Pühapäev', 'Esmaspäev', 'Teisipäev', 'Kolmapäev', 'Neljapäev', 'Reede', 'Laupäev'],
+        dayNamesShort:['Pühap', 'Esmasp', 'Teisip', 'Kolmap', 'Neljap', 'Reede', 'Laup'],
+        dayNamesMin:['P', 'E', 'T', 'K', 'N', 'R', 'L'],
+        weekHeader:'Sm',
+        dateFormat:'dd.mm.yy',
+        firstDay:1,
+        isRTL:false,
+        showMonthAfterYear:false,
+        yearSuffix:''};
 
-/* Euskarako oinarria 'UI date picker' jquery-ko extentsioarentzat */
-/* Karrikas-ek itzulia (karrikas@karrikas.com) */
-	$.datepicker.regional['eu'] = {
-		closeText: 'Egina',
-		prevText: '&#x3c;Aur',
-		nextText: 'Hur&#x3e;',
-		currentText: 'Gaur',
-		monthNames: ['Urtarrila','Otsaila','Martxoa','Apirila','Maiatza','Ekaina',
-		'Uztaila','Abuztua','Iraila','Urria','Azaroa','Abendua'],
-		monthNamesShort: ['Urt','Ots','Mar','Api','Mai','Eka',
-		'Uzt','Abu','Ira','Urr','Aza','Abe'],
-		dayNames: ['Igandea','Astelehena','Asteartea','Asteazkena','Osteguna','Ostirala','Larunbata'],
-		dayNamesShort: ['Iga','Ast','Ast','Ast','Ost','Ost','Lar'],
-		dayNamesMin: ['Ig','As','As','As','Os','Os','La'],
-		weekHeader: 'Wk',
-		dateFormat: 'yy/mm/dd',
-		firstDay: 1,
-		isRTL: false,
-		showMonthAfterYear: false,
-		yearSuffix: ''};
+    /* Euskarako oinarria 'UI date picker' jquery-ko extentsioarentzat */
+    /* Karrikas-ek itzulia (karrikas@karrikas.com) */
+    $.datepicker.regional['eu'] = {
+        closeText:'Egina',
+        prevText:'&#x3c;Aur',
+        nextText:'Hur&#x3e;',
+        currentText:'Gaur',
+        monthNames:['Urtarrila', 'Otsaila', 'Martxoa', 'Apirila', 'Maiatza', 'Ekaina',
+            'Uztaila', 'Abuztua', 'Iraila', 'Urria', 'Azaroa', 'Abendua'],
+        monthNamesShort:['Urt', 'Ots', 'Mar', 'Api', 'Mai', 'Eka',
+            'Uzt', 'Abu', 'Ira', 'Urr', 'Aza', 'Abe'],
+        dayNames:['Igandea', 'Astelehena', 'Asteartea', 'Asteazkena', 'Osteguna', 'Ostirala', 'Larunbata'],
+        dayNamesShort:['Iga', 'Ast', 'Ast', 'Ast', 'Ost', 'Ost', 'Lar'],
+        dayNamesMin:['Ig', 'As', 'As', 'As', 'Os', 'Os', 'La'],
+        weekHeader:'Wk',
+        dateFormat:'yy/mm/dd',
+        firstDay:1,
+        isRTL:false,
+        showMonthAfterYear:false,
+        yearSuffix:''};
 
-/* Persian (Farsi) Translation for the jQuery UI date picker plugin. */
-/* Javad Mowlanezhad -- jmowla@gmail.com */
-/* Jalali calendar should supported soon! (Its implemented but I have to test it) */
-	$.datepicker.regional['fa'] = {
-		closeText: 'بستن',
-		prevText: '&#x3c;قبلي',
-		nextText: 'بعدي&#x3e;',
-		currentText: 'امروز',
-		monthNames: ['فروردين','ارديبهشت','خرداد','تير','مرداد','شهريور',
-		'مهر','آبان','آذر','دي','بهمن','اسفند'],
-		monthNamesShort: ['1','2','3','4','5','6','7','8','9','10','11','12'],
-		dayNames: ['يکشنبه','دوشنبه','سه‌شنبه','چهارشنبه','پنجشنبه','جمعه','شنبه'],
-		dayNamesShort: ['ي','د','س','چ','پ','ج', 'ش'],
-		dayNamesMin: ['ي','د','س','چ','پ','ج', 'ش'],
-		weekHeader: 'هف',
-		dateFormat: 'yy/mm/dd',
-		firstDay: 6,
-		isRTL: true,
-		showMonthAfterYear: false,
-		yearSuffix: ''};
+    /* Persian (Farsi) Translation for the jQuery UI date picker plugin. */
+    /* Javad Mowlanezhad -- jmowla@gmail.com */
+    /* Jalali calendar should supported soon! (Its implemented but I have to test it) */
+    $.datepicker.regional['fa'] = {
+        closeText:'بستن',
+        prevText:'&#x3c;قبلي',
+        nextText:'بعدي&#x3e;',
+        currentText:'امروز',
+        monthNames:['فروردين', 'ارديبهشت', 'خرداد', 'تير', 'مرداد', 'شهريور',
+            'مهر', 'آبان', 'آذر', 'دي', 'بهمن', 'اسفند'],
+        monthNamesShort:['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12'],
+        dayNames:['يکشنبه', 'دوشنبه', 'سه‌شنبه', 'چهارشنبه', 'پنجشنبه', 'جمعه', 'شنبه'],
+        dayNamesShort:['ي', 'د', 'س', 'چ', 'پ', 'ج', 'ش'],
+        dayNamesMin:['ي', 'د', 'س', 'چ', 'پ', 'ج', 'ش'],
+        weekHeader:'هف',
+        dateFormat:'yy/mm/dd',
+        firstDay:6,
+        isRTL:true,
+        showMonthAfterYear:false,
+        yearSuffix:''};
 
-/* Finnish initialisation for the jQuery UI date picker plugin. */
-/* Written by Harri Kilpi� (harrikilpio@gmail.com). */
+    /* Finnish initialisation for the jQuery UI date picker plugin. */
+    /* Written by Harri Kilpi� (harrikilpio@gmail.com). */
     $.datepicker.regional['fi'] = {
-		closeText: 'Sulje',
-		prevText: '&laquo;Edellinen',
-		nextText: 'Seuraava&raquo;',
-		currentText: 'T&auml;n&auml;&auml;n',
-        monthNames: ['Tammikuu','Helmikuu','Maaliskuu','Huhtikuu','Toukokuu','Kes&auml;kuu',
-        'Hein&auml;kuu','Elokuu','Syyskuu','Lokakuu','Marraskuu','Joulukuu'],
-        monthNamesShort: ['Tammi','Helmi','Maalis','Huhti','Touko','Kes&auml;',
-        'Hein&auml;','Elo','Syys','Loka','Marras','Joulu'],
-		dayNamesShort: ['Su','Ma','Ti','Ke','To','Pe','Su'],
-		dayNames: ['Sunnuntai','Maanantai','Tiistai','Keskiviikko','Torstai','Perjantai','Lauantai'],
-		dayNamesMin: ['Su','Ma','Ti','Ke','To','Pe','La'],
-		weekHeader: 'Vk',
-        dateFormat: 'dd.mm.yy',
-		firstDay: 1,
-		isRTL: false,
-		showMonthAfterYear: false,
-		yearSuffix: ''};
+        closeText:'Sulje',
+        prevText:'&laquo;Edellinen',
+        nextText:'Seuraava&raquo;',
+        currentText:'T&auml;n&auml;&auml;n',
+        monthNames:['Tammikuu', 'Helmikuu', 'Maaliskuu', 'Huhtikuu', 'Toukokuu', 'Kes&auml;kuu',
+            'Hein&auml;kuu', 'Elokuu', 'Syyskuu', 'Lokakuu', 'Marraskuu', 'Joulukuu'],
+        monthNamesShort:['Tammi', 'Helmi', 'Maalis', 'Huhti', 'Touko', 'Kes&auml;',
+            'Hein&auml;', 'Elo', 'Syys', 'Loka', 'Marras', 'Joulu'],
+        dayNamesShort:['Su', 'Ma', 'Ti', 'Ke', 'To', 'Pe', 'Su'],
+        dayNames:['Sunnuntai', 'Maanantai', 'Tiistai', 'Keskiviikko', 'Torstai', 'Perjantai', 'Lauantai'],
+        dayNamesMin:['Su', 'Ma', 'Ti', 'Ke', 'To', 'Pe', 'La'],
+        weekHeader:'Vk',
+        dateFormat:'dd.mm.yy',
+        firstDay:1,
+        isRTL:false,
+        showMonthAfterYear:false,
+        yearSuffix:''};
 
-/* Faroese initialisation for the jQuery UI date picker plugin */
-/* Written by Sverri Mohr Olsen, sverrimo@gmail.com */
-	$.datepicker.regional['fo'] = {
-		closeText: 'Lat aftur',
-		prevText: '&#x3c;Fyrra',
-		nextText: 'Næsta&#x3e;',
-		currentText: 'Í dag',
-		monthNames: ['Januar','Februar','Mars','Apríl','Mei','Juni',
-		'Juli','August','September','Oktober','November','Desember'],
-		monthNamesShort: ['Jan','Feb','Mar','Apr','Mei','Jun',
-		'Jul','Aug','Sep','Okt','Nov','Des'],
-		dayNames: ['Sunnudagur','Mánadagur','Týsdagur','Mikudagur','Hósdagur','Fríggjadagur','Leyardagur'],
-		dayNamesShort: ['Sun','Mán','Týs','Mik','Hós','Frí','Ley'],
-		dayNamesMin: ['Su','Má','Tý','Mi','Hó','Fr','Le'],
-		weekHeader: 'Vk',
-		dateFormat: 'dd-mm-yy',
-		firstDay: 0,
-		isRTL: false,
-		showMonthAfterYear: false,
-		yearSuffix: ''};
+    /* Faroese initialisation for the jQuery UI date picker plugin */
+    /* Written by Sverri Mohr Olsen, sverrimo@gmail.com */
+    $.datepicker.regional['fo'] = {
+        closeText:'Lat aftur',
+        prevText:'&#x3c;Fyrra',
+        nextText:'Næsta&#x3e;',
+        currentText:'Í dag',
+        monthNames:['Januar', 'Februar', 'Mars', 'Apríl', 'Mei', 'Juni',
+            'Juli', 'August', 'September', 'Oktober', 'November', 'Desember'],
+        monthNamesShort:['Jan', 'Feb', 'Mar', 'Apr', 'Mei', 'Jun',
+            'Jul', 'Aug', 'Sep', 'Okt', 'Nov', 'Des'],
+        dayNames:['Sunnudagur', 'Mánadagur', 'Týsdagur', 'Mikudagur', 'Hósdagur', 'Fríggjadagur', 'Leyardagur'],
+        dayNamesShort:['Sun', 'Mán', 'Týs', 'Mik', 'Hós', 'Frí', 'Ley'],
+        dayNamesMin:['Su', 'Má', 'Tý', 'Mi', 'Hó', 'Fr', 'Le'],
+        weekHeader:'Vk',
+        dateFormat:'dd-mm-yy',
+        firstDay:0,
+        isRTL:false,
+        showMonthAfterYear:false,
+        yearSuffix:''};
 
-/* Swiss-French initialisation for the jQuery UI date picker plugin. */
-/* Written Martin Voelkle (martin.voelkle@e-tc.ch). */
-	$.datepicker.regional['fr-CH'] = {
-		closeText: 'Fermer',
-		prevText: '&#x3c;Préc',
-		nextText: 'Suiv&#x3e;',
-		currentText: 'Courant',
-		monthNames: ['Janvier','Février','Mars','Avril','Mai','Juin',
-		'Juillet','Août','Septembre','Octobre','Novembre','Décembre'],
-		monthNamesShort: ['Jan','Fév','Mar','Avr','Mai','Jun',
-		'Jul','Aoû','Sep','Oct','Nov','Déc'],
-		dayNames: ['Dimanche','Lundi','Mardi','Mercredi','Jeudi','Vendredi','Samedi'],
-		dayNamesShort: ['Dim','Lun','Mar','Mer','Jeu','Ven','Sam'],
-		dayNamesMin: ['Di','Lu','Ma','Me','Je','Ve','Sa'],
-		weekHeader: 'Sm',
-		dateFormat: 'dd.mm.yy',
-		firstDay: 1,
-		isRTL: false,
-		showMonthAfterYear: false,
-		yearSuffix: ''};
+    /* Swiss-French initialisation for the jQuery UI date picker plugin. */
+    /* Written Martin Voelkle (martin.voelkle@e-tc.ch). */
+    $.datepicker.regional['fr-CH'] = {
+        closeText:'Fermer',
+        prevText:'&#x3c;Préc',
+        nextText:'Suiv&#x3e;',
+        currentText:'Courant',
+        monthNames:['Janvier', 'Février', 'Mars', 'Avril', 'Mai', 'Juin',
+            'Juillet', 'Août', 'Septembre', 'Octobre', 'Novembre', 'Décembre'],
+        monthNamesShort:['Jan', 'Fév', 'Mar', 'Avr', 'Mai', 'Jun',
+            'Jul', 'Aoû', 'Sep', 'Oct', 'Nov', 'Déc'],
+        dayNames:['Dimanche', 'Lundi', 'Mardi', 'Mercredi', 'Jeudi', 'Vendredi', 'Samedi'],
+        dayNamesShort:['Dim', 'Lun', 'Mar', 'Mer', 'Jeu', 'Ven', 'Sam'],
+        dayNamesMin:['Di', 'Lu', 'Ma', 'Me', 'Je', 'Ve', 'Sa'],
+        weekHeader:'Sm',
+        dateFormat:'dd.mm.yy',
+        firstDay:1,
+        isRTL:false,
+        showMonthAfterYear:false,
+        yearSuffix:''};
 
-/* French initialisation for the jQuery UI date picker plugin. */
-/* Written by Keith Wood (kbwood{at}iinet.com.au),
-              Stéphane Nahmani (sholby@sholby.net),
-              Stéphane Raimbault <stephane.raimbault@gmail.com> */
-	$.datepicker.regional['fr'] = {
-		closeText: 'Fermer',
-		prevText: 'Précédent',
-		nextText: 'Suivant',
-		currentText: 'Aujourd\'hui',
-		monthNames: ['Janvier','Février','Mars','Avril','Mai','Juin',
-		'Juillet','Août','Septembre','Octobre','Novembre','Décembre'],
-		monthNamesShort: ['Janv.','Févr.','Mars','Avril','Mai','Juin',
-		'Juil.','Août','Sept.','Oct.','Nov.','Déc.'],
-		dayNames: ['Dimanche','Lundi','Mardi','Mercredi','Jeudi','Vendredi','Samedi'],
-		dayNamesShort: ['Dim.','Lun.','Mar.','Mer.','Jeu.','Ven.','Sam.'],
-		dayNamesMin: ['D','L','M','M','J','V','S'],
-		weekHeader: 'Sem.',
-		dateFormat: 'dd/mm/yy',
-		firstDay: 1,
-		isRTL: false,
-		showMonthAfterYear: false,
-		yearSuffix: ''};
+    /* French initialisation for the jQuery UI date picker plugin. */
+    /* Written by Keith Wood (kbwood{at}iinet.com.au),
+     Stéphane Nahmani (sholby@sholby.net),
+     Stéphane Raimbault <stephane.raimbault@gmail.com> */
+    $.datepicker.regional['fr'] = {
+        closeText:'Fermer',
+        prevText:'Précédent',
+        nextText:'Suivant',
+        currentText:'Aujourd\'hui',
+        monthNames:['Janvier', 'Février', 'Mars', 'Avril', 'Mai', 'Juin',
+            'Juillet', 'Août', 'Septembre', 'Octobre', 'Novembre', 'Décembre'],
+        monthNamesShort:['Janv.', 'Févr.', 'Mars', 'Avril', 'Mai', 'Juin',
+            'Juil.', 'Août', 'Sept.', 'Oct.', 'Nov.', 'Déc.'],
+        dayNames:['Dimanche', 'Lundi', 'Mardi', 'Mercredi', 'Jeudi', 'Vendredi', 'Samedi'],
+        dayNamesShort:['Dim.', 'Lun.', 'Mar.', 'Mer.', 'Jeu.', 'Ven.', 'Sam.'],
+        dayNamesMin:['D', 'L', 'M', 'M', 'J', 'V', 'S'],
+        weekHeader:'Sem.',
+        dateFormat:'dd/mm/yy',
+        firstDay:1,
+        isRTL:false,
+        showMonthAfterYear:false,
+        yearSuffix:''};
 
-/* Galician localization for 'UI date picker' jQuery extension. */
-/* Translated by Jorge Barreiro <yortx.barry@gmail.com>. */
-	$.datepicker.regional['gl'] = {
-		closeText: 'Pechar',
-		prevText: '&#x3c;Ant',
-		nextText: 'Seg&#x3e;',
-		currentText: 'Hoxe',
-		monthNames: ['Xaneiro','Febreiro','Marzo','Abril','Maio','Xuño',
-		'Xullo','Agosto','Setembro','Outubro','Novembro','Decembro'],
-		monthNamesShort: ['Xan','Feb','Mar','Abr','Mai','Xuñ',
-		'Xul','Ago','Set','Out','Nov','Dec'],
-		dayNames: ['Domingo','Luns','Martes','M&eacute;rcores','Xoves','Venres','S&aacute;bado'],
-		dayNamesShort: ['Dom','Lun','Mar','M&eacute;r','Xov','Ven','S&aacute;b'],
-		dayNamesMin: ['Do','Lu','Ma','M&eacute;','Xo','Ve','S&aacute;'],
-		weekHeader: 'Sm',
-		dateFormat: 'dd/mm/yy',
-		firstDay: 1,
-		isRTL: false,
-		showMonthAfterYear: false,
-		yearSuffix: ''};
+    /* Galician localization for 'UI date picker' jQuery extension. */
+    /* Translated by Jorge Barreiro <yortx.barry@gmail.com>. */
+    $.datepicker.regional['gl'] = {
+        closeText:'Pechar',
+        prevText:'&#x3c;Ant',
+        nextText:'Seg&#x3e;',
+        currentText:'Hoxe',
+        monthNames:['Xaneiro', 'Febreiro', 'Marzo', 'Abril', 'Maio', 'Xuño',
+            'Xullo', 'Agosto', 'Setembro', 'Outubro', 'Novembro', 'Decembro'],
+        monthNamesShort:['Xan', 'Feb', 'Mar', 'Abr', 'Mai', 'Xuñ',
+            'Xul', 'Ago', 'Set', 'Out', 'Nov', 'Dec'],
+        dayNames:['Domingo', 'Luns', 'Martes', 'M&eacute;rcores', 'Xoves', 'Venres', 'S&aacute;bado'],
+        dayNamesShort:['Dom', 'Lun', 'Mar', 'M&eacute;r', 'Xov', 'Ven', 'S&aacute;b'],
+        dayNamesMin:['Do', 'Lu', 'Ma', 'M&eacute;', 'Xo', 'Ve', 'S&aacute;'],
+        weekHeader:'Sm',
+        dateFormat:'dd/mm/yy',
+        firstDay:1,
+        isRTL:false,
+        showMonthAfterYear:false,
+        yearSuffix:''};
 
-/* Hebrew initialisation for the UI Datepicker extension. */
-/* Written by Amir Hardon (ahardon at gmail dot com). */
-	$.datepicker.regional['he'] = {
-		closeText: 'סגור',
-		prevText: '&#x3c;הקודם',
-		nextText: 'הבא&#x3e;',
-		currentText: 'היום',
-		monthNames: ['ינואר','פברואר','מרץ','אפריל','מאי','יוני',
-		'יולי','אוגוסט','ספטמבר','אוקטובר','נובמבר','דצמבר'],
-		monthNamesShort: ['1','2','3','4','5','6',
-		'7','8','9','10','11','12'],
-		dayNames: ['ראשון','שני','שלישי','רביעי','חמישי','שישי','שבת'],
-		dayNamesShort: ['א\'','ב\'','ג\'','ד\'','ה\'','ו\'','שבת'],
-		dayNamesMin: ['א\'','ב\'','ג\'','ד\'','ה\'','ו\'','שבת'],
-		weekHeader: 'Wk',
-		dateFormat: 'dd/mm/yy',
-		firstDay: 0,
-		isRTL: true,
-		showMonthAfterYear: false,
-		yearSuffix: ''};
+    /* Hebrew initialisation for the UI Datepicker extension. */
+    /* Written by Amir Hardon (ahardon at gmail dot com). */
+    $.datepicker.regional['he'] = {
+        closeText:'סגור',
+        prevText:'&#x3c;הקודם',
+        nextText:'הבא&#x3e;',
+        currentText:'היום',
+        monthNames:['ינואר', 'פברואר', 'מרץ', 'אפריל', 'מאי', 'יוני',
+            'יולי', 'אוגוסט', 'ספטמבר', 'אוקטובר', 'נובמבר', 'דצמבר'],
+        monthNamesShort:['1', '2', '3', '4', '5', '6',
+            '7', '8', '9', '10', '11', '12'],
+        dayNames:['ראשון', 'שני', 'שלישי', 'רביעי', 'חמישי', 'שישי', 'שבת'],
+        dayNamesShort:['א\'', 'ב\'', 'ג\'', 'ד\'', 'ה\'', 'ו\'', 'שבת'],
+        dayNamesMin:['א\'', 'ב\'', 'ג\'', 'ד\'', 'ה\'', 'ו\'', 'שבת'],
+        weekHeader:'Wk',
+        dateFormat:'dd/mm/yy',
+        firstDay:0,
+        isRTL:true,
+        showMonthAfterYear:false,
+        yearSuffix:''};
 
-/* Croatian i18n for the jQuery UI date picker plugin. */
-/* Written by Vjekoslav Nesek. */
-	$.datepicker.regional['hr'] = {
-		closeText: 'Zatvori',
-		prevText: '&#x3c;',
-		nextText: '&#x3e;',
-		currentText: 'Danas',
-		monthNames: ['Siječanj','Veljača','Ožujak','Travanj','Svibanj','Lipanj',
-		'Srpanj','Kolovoz','Rujan','Listopad','Studeni','Prosinac'],
-		monthNamesShort: ['Sij','Velj','Ožu','Tra','Svi','Lip',
-		'Srp','Kol','Ruj','Lis','Stu','Pro'],
-		dayNames: ['Nedjelja','Ponedjeljak','Utorak','Srijeda','Četvrtak','Petak','Subota'],
-		dayNamesShort: ['Ned','Pon','Uto','Sri','Čet','Pet','Sub'],
-		dayNamesMin: ['Ne','Po','Ut','Sr','Če','Pe','Su'],
-		weekHeader: 'Tje',
-		dateFormat: 'dd.mm.yy.',
-		firstDay: 1,
-		isRTL: false,
-		showMonthAfterYear: false,
-		yearSuffix: ''};
+    /* Croatian i18n for the jQuery UI date picker plugin. */
+    /* Written by Vjekoslav Nesek. */
+    $.datepicker.regional['hr'] = {
+        closeText:'Zatvori',
+        prevText:'&#x3c;',
+        nextText:'&#x3e;',
+        currentText:'Danas',
+        monthNames:['Siječanj', 'Veljača', 'Ožujak', 'Travanj', 'Svibanj', 'Lipanj',
+            'Srpanj', 'Kolovoz', 'Rujan', 'Listopad', 'Studeni', 'Prosinac'],
+        monthNamesShort:['Sij', 'Velj', 'Ožu', 'Tra', 'Svi', 'Lip',
+            'Srp', 'Kol', 'Ruj', 'Lis', 'Stu', 'Pro'],
+        dayNames:['Nedjelja', 'Ponedjeljak', 'Utorak', 'Srijeda', 'Četvrtak', 'Petak', 'Subota'],
+        dayNamesShort:['Ned', 'Pon', 'Uto', 'Sri', 'Čet', 'Pet', 'Sub'],
+        dayNamesMin:['Ne', 'Po', 'Ut', 'Sr', 'Če', 'Pe', 'Su'],
+        weekHeader:'Tje',
+        dateFormat:'dd.mm.yy.',
+        firstDay:1,
+        isRTL:false,
+        showMonthAfterYear:false,
+        yearSuffix:''};
 
-/* Hungarian initialisation for the jQuery UI date picker plugin. */
-/* Written by Istvan Karaszi (jquery@spam.raszi.hu). */
-	$.datepicker.regional['hu'] = {
-		closeText: 'bezárás',
-		prevText: '&laquo;&nbsp;vissza',
-		nextText: 'előre&nbsp;&raquo;',
-		currentText: 'ma',
-		monthNames: ['Január', 'Február', 'Március', 'Április', 'Május', 'Június',
-		'Július', 'Augusztus', 'Szeptember', 'Október', 'November', 'December'],
-		monthNamesShort: ['Jan', 'Feb', 'Már', 'Ápr', 'Máj', 'Jún',
-		'Júl', 'Aug', 'Szep', 'Okt', 'Nov', 'Dec'],
-		dayNames: ['Vasárnap', 'Hétfö', 'Kedd', 'Szerda', 'Csütörtök', 'Péntek', 'Szombat'],
-		dayNamesShort: ['Vas', 'Hét', 'Ked', 'Sze', 'Csü', 'Pén', 'Szo'],
-		dayNamesMin: ['V', 'H', 'K', 'Sze', 'Cs', 'P', 'Szo'],
-		weekHeader: 'Hé',
-		dateFormat: 'yy-mm-dd',
-		firstDay: 1,
-		isRTL: false,
-		showMonthAfterYear: true,
-		yearSuffix: ''};
+    /* Hungarian initialisation for the jQuery UI date picker plugin. */
+    /* Written by Istvan Karaszi (jquery@spam.raszi.hu). */
+    $.datepicker.regional['hu'] = {
+        closeText:'bezárás',
+        prevText:'&laquo;&nbsp;vissza',
+        nextText:'előre&nbsp;&raquo;',
+        currentText:'ma',
+        monthNames:['Január', 'Február', 'Március', 'Április', 'Május', 'Június',
+            'Július', 'Augusztus', 'Szeptember', 'Október', 'November', 'December'],
+        monthNamesShort:['Jan', 'Feb', 'Már', 'Ápr', 'Máj', 'Jún',
+            'Júl', 'Aug', 'Szep', 'Okt', 'Nov', 'Dec'],
+        dayNames:['Vasárnap', 'Hétfö', 'Kedd', 'Szerda', 'Csütörtök', 'Péntek', 'Szombat'],
+        dayNamesShort:['Vas', 'Hét', 'Ked', 'Sze', 'Csü', 'Pén', 'Szo'],
+        dayNamesMin:['V', 'H', 'K', 'Sze', 'Cs', 'P', 'Szo'],
+        weekHeader:'Hé',
+        dateFormat:'yy-mm-dd',
+        firstDay:1,
+        isRTL:false,
+        showMonthAfterYear:true,
+        yearSuffix:''};
 
-/* Armenian(UTF-8) initialisation for the jQuery UI date picker plugin. */
-/* Written by Levon Zakaryan (levon.zakaryan@gmail.com)*/
-	$.datepicker.regional['hy'] = {
-		closeText: 'Փակել',
-		prevText: '&#x3c;Նախ.',
-		nextText: 'Հաջ.&#x3e;',
-		currentText: 'Այսօր',
-		monthNames: ['Հունվար','Փետրվար','Մարտ','Ապրիլ','Մայիս','Հունիս',
-		'Հուլիս','Օգոստոս','Սեպտեմբեր','Հոկտեմբեր','Նոյեմբեր','Դեկտեմբեր'],
-		monthNamesShort: ['Հունվ','Փետր','Մարտ','Ապր','Մայիս','Հունիս',
-		'Հուլ','Օգս','Սեպ','Հոկ','Նոյ','Դեկ'],
-		dayNames: ['կիրակի','եկուշաբթի','երեքշաբթի','չորեքշաբթի','հինգշաբթի','ուրբաթ','շաբաթ'],
-		dayNamesShort: ['կիր','երկ','երք','չրք','հնգ','ուրբ','շբթ'],
-		dayNamesMin: ['կիր','երկ','երք','չրք','հնգ','ուրբ','շբթ'],
-		weekHeader: 'ՇԲՏ',
-		dateFormat: 'dd.mm.yy',
-		firstDay: 1,
-		isRTL: false,
-		showMonthAfterYear: false,
-		yearSuffix: ''};
+    /* Armenian(UTF-8) initialisation for the jQuery UI date picker plugin. */
+    /* Written by Levon Zakaryan (levon.zakaryan@gmail.com)*/
+    $.datepicker.regional['hy'] = {
+        closeText:'Փակել',
+        prevText:'&#x3c;Նախ.',
+        nextText:'Հաջ.&#x3e;',
+        currentText:'Այսօր',
+        monthNames:['Հունվար', 'Փետրվար', 'Մարտ', 'Ապրիլ', 'Մայիս', 'Հունիս',
+            'Հուլիս', 'Օգոստոս', 'Սեպտեմբեր', 'Հոկտեմբեր', 'Նոյեմբեր', 'Դեկտեմբեր'],
+        monthNamesShort:['Հունվ', 'Փետր', 'Մարտ', 'Ապր', 'Մայիս', 'Հունիս',
+            'Հուլ', 'Օգս', 'Սեպ', 'Հոկ', 'Նոյ', 'Դեկ'],
+        dayNames:['կիրակի', 'եկուշաբթի', 'երեքշաբթի', 'չորեքշաբթի', 'հինգշաբթի', 'ուրբաթ', 'շաբաթ'],
+        dayNamesShort:['կիր', 'երկ', 'երք', 'չրք', 'հնգ', 'ուրբ', 'շբթ'],
+        dayNamesMin:['կիր', 'երկ', 'երք', 'չրք', 'հնգ', 'ուրբ', 'շբթ'],
+        weekHeader:'ՇԲՏ',
+        dateFormat:'dd.mm.yy',
+        firstDay:1,
+        isRTL:false,
+        showMonthAfterYear:false,
+        yearSuffix:''};
 
-/* Indonesian initialisation for the jQuery UI date picker plugin. */
-/* Written by Deden Fathurahman (dedenf@gmail.com). */
-	$.datepicker.regional['id'] = {
-		closeText: 'Tutup',
-		prevText: '&#x3c;mundur',
-		nextText: 'maju&#x3e;',
-		currentText: 'hari ini',
-		monthNames: ['Januari','Februari','Maret','April','Mei','Juni',
-		'Juli','Agustus','September','Oktober','Nopember','Desember'],
-		monthNamesShort: ['Jan','Feb','Mar','Apr','Mei','Jun',
-		'Jul','Agus','Sep','Okt','Nop','Des'],
-		dayNames: ['Minggu','Senin','Selasa','Rabu','Kamis','Jumat','Sabtu'],
-		dayNamesShort: ['Min','Sen','Sel','Rab','kam','Jum','Sab'],
-		dayNamesMin: ['Mg','Sn','Sl','Rb','Km','jm','Sb'],
-		weekHeader: 'Mg',
-		dateFormat: 'dd/mm/yy',
-		firstDay: 0,
-		isRTL: false,
-		showMonthAfterYear: false,
-		yearSuffix: ''};
+    /* Indonesian initialisation for the jQuery UI date picker plugin. */
+    /* Written by Deden Fathurahman (dedenf@gmail.com). */
+    $.datepicker.regional['id'] = {
+        closeText:'Tutup',
+        prevText:'&#x3c;mundur',
+        nextText:'maju&#x3e;',
+        currentText:'hari ini',
+        monthNames:['Januari', 'Februari', 'Maret', 'April', 'Mei', 'Juni',
+            'Juli', 'Agustus', 'September', 'Oktober', 'Nopember', 'Desember'],
+        monthNamesShort:['Jan', 'Feb', 'Mar', 'Apr', 'Mei', 'Jun',
+            'Jul', 'Agus', 'Sep', 'Okt', 'Nop', 'Des'],
+        dayNames:['Minggu', 'Senin', 'Selasa', 'Rabu', 'Kamis', 'Jumat', 'Sabtu'],
+        dayNamesShort:['Min', 'Sen', 'Sel', 'Rab', 'kam', 'Jum', 'Sab'],
+        dayNamesMin:['Mg', 'Sn', 'Sl', 'Rb', 'Km', 'jm', 'Sb'],
+        weekHeader:'Mg',
+        dateFormat:'dd/mm/yy',
+        firstDay:0,
+        isRTL:false,
+        showMonthAfterYear:false,
+        yearSuffix:''};
 
-/* Icelandic initialisation for the jQuery UI date picker plugin. */
-/* Written by Haukur H. Thorsson (haukur@eskill.is). */
-	$.datepicker.regional['is'] = {
-		closeText: 'Loka',
-		prevText: '&#x3c; Fyrri',
-		nextText: 'N&aelig;sti &#x3e;',
-		currentText: '&Iacute; dag',
-		monthNames: ['Jan&uacute;ar','Febr&uacute;ar','Mars','Apr&iacute;l','Ma&iacute','J&uacute;n&iacute;',
-		'J&uacute;l&iacute;','&Aacute;g&uacute;st','September','Okt&oacute;ber','N&oacute;vember','Desember'],
-		monthNamesShort: ['Jan','Feb','Mar','Apr','Ma&iacute;','J&uacute;n',
-		'J&uacute;l','&Aacute;g&uacute;','Sep','Okt','N&oacute;v','Des'],
-		dayNames: ['Sunnudagur','M&aacute;nudagur','&THORN;ri&eth;judagur','Mi&eth;vikudagur','Fimmtudagur','F&ouml;studagur','Laugardagur'],
-		dayNamesShort: ['Sun','M&aacute;n','&THORN;ri','Mi&eth;','Fim','F&ouml;s','Lau'],
-		dayNamesMin: ['Su','M&aacute;','&THORN;r','Mi','Fi','F&ouml;','La'],
-		weekHeader: 'Vika',
-		dateFormat: 'dd/mm/yy',
-		firstDay: 0,
-		isRTL: false,
-		showMonthAfterYear: false,
-		yearSuffix: ''};
+    /* Icelandic initialisation for the jQuery UI date picker plugin. */
+    /* Written by Haukur H. Thorsson (haukur@eskill.is). */
+    $.datepicker.regional['is'] = {
+        closeText:'Loka',
+        prevText:'&#x3c; Fyrri',
+        nextText:'N&aelig;sti &#x3e;',
+        currentText:'&Iacute; dag',
+        monthNames:['Jan&uacute;ar', 'Febr&uacute;ar', 'Mars', 'Apr&iacute;l', 'Ma&iacute', 'J&uacute;n&iacute;',
+            'J&uacute;l&iacute;', '&Aacute;g&uacute;st', 'September', 'Okt&oacute;ber', 'N&oacute;vember', 'Desember'],
+        monthNamesShort:['Jan', 'Feb', 'Mar', 'Apr', 'Ma&iacute;', 'J&uacute;n',
+            'J&uacute;l', '&Aacute;g&uacute;', 'Sep', 'Okt', 'N&oacute;v', 'Des'],
+        dayNames:['Sunnudagur', 'M&aacute;nudagur', '&THORN;ri&eth;judagur', 'Mi&eth;vikudagur', 'Fimmtudagur', 'F&ouml;studagur', 'Laugardagur'],
+        dayNamesShort:['Sun', 'M&aacute;n', '&THORN;ri', 'Mi&eth;', 'Fim', 'F&ouml;s', 'Lau'],
+        dayNamesMin:['Su', 'M&aacute;', '&THORN;r', 'Mi', 'Fi', 'F&ouml;', 'La'],
+        weekHeader:'Vika',
+        dateFormat:'dd/mm/yy',
+        firstDay:0,
+        isRTL:false,
+        showMonthAfterYear:false,
+        yearSuffix:''};
 
-/* Italian initialisation for the jQuery UI date picker plugin. */
-/* Written by Antonello Pasella (antonello.pasella@gmail.com). */
-	$.datepicker.regional['it'] = {
-		closeText: 'Chiudi',
-		prevText: '&#x3c;Prec',
-		nextText: 'Succ&#x3e;',
-		currentText: 'Oggi',
-		monthNames: ['Gennaio','Febbraio','Marzo','Aprile','Maggio','Giugno',
-			'Luglio','Agosto','Settembre','Ottobre','Novembre','Dicembre'],
-		monthNamesShort: ['Gen','Feb','Mar','Apr','Mag','Giu',
-			'Lug','Ago','Set','Ott','Nov','Dic'],
-		dayNames: ['Domenica','Luned&#236','Marted&#236','Mercoled&#236','Gioved&#236','Venerd&#236','Sabato'],
-		dayNamesShort: ['Dom','Lun','Mar','Mer','Gio','Ven','Sab'],
-		dayNamesMin: ['Do','Lu','Ma','Me','Gi','Ve','Sa'],
-		weekHeader: 'Sm',
-		dateFormat: 'dd/mm/yy',
-		firstDay: 1,
-		isRTL: false,
-		showMonthAfterYear: false,
-		yearSuffix: ''};
+    /* Italian initialisation for the jQuery UI date picker plugin. */
+    /* Written by Antonello Pasella (antonello.pasella@gmail.com). */
+    $.datepicker.regional['it'] = {
+        closeText:'Chiudi',
+        prevText:'&#x3c;Prec',
+        nextText:'Succ&#x3e;',
+        currentText:'Oggi',
+        monthNames:['Gennaio', 'Febbraio', 'Marzo', 'Aprile', 'Maggio', 'Giugno',
+            'Luglio', 'Agosto', 'Settembre', 'Ottobre', 'Novembre', 'Dicembre'],
+        monthNamesShort:['Gen', 'Feb', 'Mar', 'Apr', 'Mag', 'Giu',
+            'Lug', 'Ago', 'Set', 'Ott', 'Nov', 'Dic'],
+        dayNames:['Domenica', 'Luned&#236', 'Marted&#236', 'Mercoled&#236', 'Gioved&#236', 'Venerd&#236', 'Sabato'],
+        dayNamesShort:['Dom', 'Lun', 'Mar', 'Mer', 'Gio', 'Ven', 'Sab'],
+        dayNamesMin:['Do', 'Lu', 'Ma', 'Me', 'Gi', 'Ve', 'Sa'],
+        weekHeader:'Sm',
+        dateFormat:'dd/mm/yy',
+        firstDay:1,
+        isRTL:false,
+        showMonthAfterYear:false,
+        yearSuffix:''};
 
-/* Japanese initialisation for the jQuery UI date picker plugin. */
-/* Written by Kentaro SATO (kentaro@ranvis.com). */
-	$.datepicker.regional['ja'] = {
-		closeText: '閉じる',
-		prevText: '&#x3c;前',
-		nextText: '次&#x3e;',
-		currentText: '今日',
-		monthNames: ['1月','2月','3月','4月','5月','6月',
-		'7月','8月','9月','10月','11月','12月'],
-		monthNamesShort: ['1月','2月','3月','4月','5月','6月',
-		'7月','8月','9月','10月','11月','12月'],
-		dayNames: ['日曜日','月曜日','火曜日','水曜日','木曜日','金曜日','土曜日'],
-		dayNamesShort: ['日','月','火','水','木','金','土'],
-		dayNamesMin: ['日','月','火','水','木','金','土'],
-		weekHeader: '週',
-		dateFormat: 'yy/mm/dd',
-		firstDay: 0,
-		isRTL: false,
-		showMonthAfterYear: true,
-		yearSuffix: '年'};
+    /* Japanese initialisation for the jQuery UI date picker plugin. */
+    /* Written by Kentaro SATO (kentaro@ranvis.com). */
+    $.datepicker.regional['ja'] = {
+        closeText:'閉じる',
+        prevText:'&#x3c;前',
+        nextText:'次&#x3e;',
+        currentText:'今日',
+        monthNames:['1月', '2月', '3月', '4月', '5月', '6月',
+            '7月', '8月', '9月', '10月', '11月', '12月'],
+        monthNamesShort:['1月', '2月', '3月', '4月', '5月', '6月',
+            '7月', '8月', '9月', '10月', '11月', '12月'],
+        dayNames:['日曜日', '月曜日', '火曜日', '水曜日', '木曜日', '金曜日', '土曜日'],
+        dayNamesShort:['日', '月', '火', '水', '木', '金', '土'],
+        dayNamesMin:['日', '月', '火', '水', '木', '金', '土'],
+        weekHeader:'週',
+        dateFormat:'yy/mm/dd',
+        firstDay:0,
+        isRTL:false,
+        showMonthAfterYear:true,
+        yearSuffix:'年'};
 
-/* Korean initialisation for the jQuery calendar extension. */
-/* Written by DaeKwon Kang (ncrash.dk@gmail.com). */
-	$.datepicker.regional['ko'] = {
-		closeText: '닫기',
-		prevText: '이전달',
-		nextText: '다음달',
-		currentText: '오늘',
-		monthNames: ['1월(JAN)','2월(FEB)','3월(MAR)','4월(APR)','5월(MAY)','6월(JUN)',
-		'7월(JUL)','8월(AUG)','9월(SEP)','10월(OCT)','11월(NOV)','12월(DEC)'],
-		monthNamesShort: ['1월(JAN)','2월(FEB)','3월(MAR)','4월(APR)','5월(MAY)','6월(JUN)',
-		'7월(JUL)','8월(AUG)','9월(SEP)','10월(OCT)','11월(NOV)','12월(DEC)'],
-		dayNames: ['일','월','화','수','목','금','토'],
-		dayNamesShort: ['일','월','화','수','목','금','토'],
-		dayNamesMin: ['일','월','화','수','목','금','토'],
-		weekHeader: 'Wk',
-		dateFormat: 'yy-mm-dd',
-		firstDay: 0,
-		isRTL: false,
-		showMonthAfterYear: false,
-		yearSuffix: '년'};
+    /* Korean initialisation for the jQuery calendar extension. */
+    /* Written by DaeKwon Kang (ncrash.dk@gmail.com). */
+    $.datepicker.regional['ko'] = {
+        closeText:'닫기',
+        prevText:'이전달',
+        nextText:'다음달',
+        currentText:'오늘',
+        monthNames:['1월(JAN)', '2월(FEB)', '3월(MAR)', '4월(APR)', '5월(MAY)', '6월(JUN)',
+            '7월(JUL)', '8월(AUG)', '9월(SEP)', '10월(OCT)', '11월(NOV)', '12월(DEC)'],
+        monthNamesShort:['1월(JAN)', '2월(FEB)', '3월(MAR)', '4월(APR)', '5월(MAY)', '6월(JUN)',
+            '7월(JUL)', '8월(AUG)', '9월(SEP)', '10월(OCT)', '11월(NOV)', '12월(DEC)'],
+        dayNames:['일', '월', '화', '수', '목', '금', '토'],
+        dayNamesShort:['일', '월', '화', '수', '목', '금', '토'],
+        dayNamesMin:['일', '월', '화', '수', '목', '금', '토'],
+        weekHeader:'Wk',
+        dateFormat:'yy-mm-dd',
+        firstDay:0,
+        isRTL:false,
+        showMonthAfterYear:false,
+        yearSuffix:'년'};
 
-/* Kazakh (UTF-8) initialisation for the jQuery UI date picker plugin. */
-/* Written by Dmitriy Karasyov (dmitriy.karasyov@gmail.com). */
-	$.datepicker.regional['kz'] = {
-		closeText: 'Жабу',
-		prevText: '&#x3c;Алдыңғы',
-		nextText: 'Келесі&#x3e;',
-		currentText: 'Бүгін',
-		monthNames: ['Қаңтар','Ақпан','Наурыз','Сәуір','Мамыр','Маусым',
-		'Шілде','Тамыз','Қыркүйек','Қазан','Қараша','Желтоқсан'],
-		monthNamesShort: ['Қаң','Ақп','Нау','Сәу','Мам','Мау',
-		'Шіл','Там','Қыр','Қаз','Қар','Жел'],
-		dayNames: ['Жексенбі','Дүйсенбі','Сейсенбі','Сәрсенбі','Бейсенбі','Жұма','Сенбі'],
-		dayNamesShort: ['жкс','дсн','ссн','срс','бсн','жма','снб'],
-		dayNamesMin: ['Жк','Дс','Сс','Ср','Бс','Жм','Сн'],
-		weekHeader: 'Не',
-		dateFormat: 'dd.mm.yy',
-		firstDay: 1,
-		isRTL: false,
-		showMonthAfterYear: false,
-		yearSuffix: ''};
+    /* Kazakh (UTF-8) initialisation for the jQuery UI date picker plugin. */
+    /* Written by Dmitriy Karasyov (dmitriy.karasyov@gmail.com). */
+    $.datepicker.regional['kz'] = {
+        closeText:'Жабу',
+        prevText:'&#x3c;Алдыңғы',
+        nextText:'Келесі&#x3e;',
+        currentText:'Бүгін',
+        monthNames:['Қаңтар', 'Ақпан', 'Наурыз', 'Сәуір', 'Мамыр', 'Маусым',
+            'Шілде', 'Тамыз', 'Қыркүйек', 'Қазан', 'Қараша', 'Желтоқсан'],
+        monthNamesShort:['Қаң', 'Ақп', 'Нау', 'Сәу', 'Мам', 'Мау',
+            'Шіл', 'Там', 'Қыр', 'Қаз', 'Қар', 'Жел'],
+        dayNames:['Жексенбі', 'Дүйсенбі', 'Сейсенбі', 'Сәрсенбі', 'Бейсенбі', 'Жұма', 'Сенбі'],
+        dayNamesShort:['жкс', 'дсн', 'ссн', 'срс', 'бсн', 'жма', 'снб'],
+        dayNamesMin:['Жк', 'Дс', 'Сс', 'Ср', 'Бс', 'Жм', 'Сн'],
+        weekHeader:'Не',
+        dateFormat:'dd.mm.yy',
+        firstDay:1,
+        isRTL:false,
+        showMonthAfterYear:false,
+        yearSuffix:''};
 
-/* Lithuanian (UTF-8) initialisation for the jQuery UI date picker plugin. */
-/* @author Arturas Paleicikas <arturas@avalon.lt> */
-	$.datepicker.regional['lt'] = {
-		closeText: 'Uždaryti',
-		prevText: '&#x3c;Atgal',
-		nextText: 'Pirmyn&#x3e;',
-		currentText: 'Šiandien',
-		monthNames: ['Sausis','Vasaris','Kovas','Balandis','Gegužė','Birželis',
-		'Liepa','Rugpjūtis','Rugsėjis','Spalis','Lapkritis','Gruodis'],
-		monthNamesShort: ['Sau','Vas','Kov','Bal','Geg','Bir',
-		'Lie','Rugp','Rugs','Spa','Lap','Gru'],
-		dayNames: ['sekmadienis','pirmadienis','antradienis','trečiadienis','ketvirtadienis','penktadienis','šeštadienis'],
-		dayNamesShort: ['sek','pir','ant','tre','ket','pen','šeš'],
-		dayNamesMin: ['Se','Pr','An','Tr','Ke','Pe','Še'],
-		weekHeader: 'Wk',
-		dateFormat: 'yy-mm-dd',
-		firstDay: 1,
-		isRTL: false,
-		showMonthAfterYear: false,
-		yearSuffix: ''};
+    /* Lithuanian (UTF-8) initialisation for the jQuery UI date picker plugin. */
+    /* @author Arturas Paleicikas <arturas@avalon.lt> */
+    $.datepicker.regional['lt'] = {
+        closeText:'Uždaryti',
+        prevText:'&#x3c;Atgal',
+        nextText:'Pirmyn&#x3e;',
+        currentText:'Šiandien',
+        monthNames:['Sausis', 'Vasaris', 'Kovas', 'Balandis', 'Gegužė', 'Birželis',
+            'Liepa', 'Rugpjūtis', 'Rugsėjis', 'Spalis', 'Lapkritis', 'Gruodis'],
+        monthNamesShort:['Sau', 'Vas', 'Kov', 'Bal', 'Geg', 'Bir',
+            'Lie', 'Rugp', 'Rugs', 'Spa', 'Lap', 'Gru'],
+        dayNames:['sekmadienis', 'pirmadienis', 'antradienis', 'trečiadienis', 'ketvirtadienis', 'penktadienis', 'šeštadienis'],
+        dayNamesShort:['sek', 'pir', 'ant', 'tre', 'ket', 'pen', 'šeš'],
+        dayNamesMin:['Se', 'Pr', 'An', 'Tr', 'Ke', 'Pe', 'Še'],
+        weekHeader:'Wk',
+        dateFormat:'yy-mm-dd',
+        firstDay:1,
+        isRTL:false,
+        showMonthAfterYear:false,
+        yearSuffix:''};
 
-/* Latvian (UTF-8) initialisation for the jQuery UI date picker plugin. */
-/* @author Arturas Paleicikas <arturas.paleicikas@metasite.net> */
-	$.datepicker.regional['lv'] = {
-		closeText: 'Aizvērt',
-		prevText: 'Iepr',
-		nextText: 'Nāka',
-		currentText: 'Šodien',
-		monthNames: ['Janvāris','Februāris','Marts','Aprīlis','Maijs','Jūnijs',
-		'Jūlijs','Augusts','Septembris','Oktobris','Novembris','Decembris'],
-		monthNamesShort: ['Jan','Feb','Mar','Apr','Mai','Jūn',
-		'Jūl','Aug','Sep','Okt','Nov','Dec'],
-		dayNames: ['svētdiena','pirmdiena','otrdiena','trešdiena','ceturtdiena','piektdiena','sestdiena'],
-		dayNamesShort: ['svt','prm','otr','tre','ctr','pkt','sst'],
-		dayNamesMin: ['Sv','Pr','Ot','Tr','Ct','Pk','Ss'],
-		weekHeader: 'Nav',
-		dateFormat: 'dd-mm-yy',
-		firstDay: 1,
-		isRTL: false,
-		showMonthAfterYear: false,
-		yearSuffix: ''};
+    /* Latvian (UTF-8) initialisation for the jQuery UI date picker plugin. */
+    /* @author Arturas Paleicikas <arturas.paleicikas@metasite.net> */
+    $.datepicker.regional['lv'] = {
+        closeText:'Aizvērt',
+        prevText:'Iepr',
+        nextText:'Nāka',
+        currentText:'Šodien',
+        monthNames:['Janvāris', 'Februāris', 'Marts', 'Aprīlis', 'Maijs', 'Jūnijs',
+            'Jūlijs', 'Augusts', 'Septembris', 'Oktobris', 'Novembris', 'Decembris'],
+        monthNamesShort:['Jan', 'Feb', 'Mar', 'Apr', 'Mai', 'Jūn',
+            'Jūl', 'Aug', 'Sep', 'Okt', 'Nov', 'Dec'],
+        dayNames:['svētdiena', 'pirmdiena', 'otrdiena', 'trešdiena', 'ceturtdiena', 'piektdiena', 'sestdiena'],
+        dayNamesShort:['svt', 'prm', 'otr', 'tre', 'ctr', 'pkt', 'sst'],
+        dayNamesMin:['Sv', 'Pr', 'Ot', 'Tr', 'Ct', 'Pk', 'Ss'],
+        weekHeader:'Nav',
+        dateFormat:'dd-mm-yy',
+        firstDay:1,
+        isRTL:false,
+        showMonthAfterYear:false,
+        yearSuffix:''};
 
-/* Malayalam (UTF-8) initialisation for the jQuery UI date picker plugin. */
-/* Written by Saji Nediyanchath (saji89@gmail.com). */
-	$.datepicker.regional['ml'] = {
-		closeText: 'ശരി',
-		prevText: 'മുന്നത്തെ',  
-		nextText: 'അടുത്തത് ',
-		currentText: 'ഇന്ന്',
-		monthNames: ['ജനുവരി','ഫെബ്രുവരി','മാര്‍ച്ച്','ഏപ്രില്‍','മേയ്','ജൂണ്‍',
-		'ജൂലൈ','ആഗസ്റ്റ്','സെപ്റ്റംബര്‍','ഒക്ടോബര്‍','നവംബര്‍','ഡിസംബര്‍'],
-		monthNamesShort: ['ജനു', 'ഫെബ്', 'മാര്‍', 'ഏപ്രി', 'മേയ്', 'ജൂണ്‍',
-		'ജൂലാ', 'ആഗ', 'സെപ്', 'ഒക്ടോ', 'നവം', 'ഡിസ'],
-		dayNames: ['ഞായര്‍', 'തിങ്കള്‍', 'ചൊവ്വ', 'ബുധന്‍', 'വ്യാഴം', 'വെള്ളി', 'ശനി'],
-		dayNamesShort: ['ഞായ', 'തിങ്ക', 'ചൊവ്വ', 'ബുധ', 'വ്യാഴം', 'വെള്ളി', 'ശനി'],
-		dayNamesMin: ['ഞാ','തി','ചൊ','ബു','വ്യാ','വെ','ശ'],
-		weekHeader: 'ആ',
-		dateFormat: 'dd/mm/yy',
-		firstDay: 1,
-		isRTL: false,
-		showMonthAfterYear: false,
-		yearSuffix: ''};
+    /* Malayalam (UTF-8) initialisation for the jQuery UI date picker plugin. */
+    /* Written by Saji Nediyanchath (saji89@gmail.com). */
+    $.datepicker.regional['ml'] = {
+        closeText:'ശരി',
+        prevText:'മുന്നത്തെ',
+        nextText:'അടുത്തത് ',
+        currentText:'ഇന്ന്',
+        monthNames:['ജനുവരി', 'ഫെബ്രുവരി', 'മാര്‍ച്ച്', 'ഏപ്രില്‍', 'മേയ്', 'ജൂണ്‍',
+            'ജൂലൈ', 'ആഗസ്റ്റ്', 'സെപ്റ്റംബര്‍', 'ഒക്ടോബര്‍', 'നവംബര്‍', 'ഡിസംബര്‍'],
+        monthNamesShort:['ജനു', 'ഫെബ്', 'മാര്‍', 'ഏപ്രി', 'മേയ്', 'ജൂണ്‍',
+            'ജൂലാ', 'ആഗ', 'സെപ്', 'ഒക്ടോ', 'നവം', 'ഡിസ'],
+        dayNames:['ഞായര്‍', 'തിങ്കള്‍', 'ചൊവ്വ', 'ബുധന്‍', 'വ്യാഴം', 'വെള്ളി', 'ശനി'],
+        dayNamesShort:['ഞായ', 'തിങ്ക', 'ചൊവ്വ', 'ബുധ', 'വ്യാഴം', 'വെള്ളി', 'ശനി'],
+        dayNamesMin:['ഞാ', 'തി', 'ചൊ', 'ബു', 'വ്യാ', 'വെ', 'ശ'],
+        weekHeader:'ആ',
+        dateFormat:'dd/mm/yy',
+        firstDay:1,
+        isRTL:false,
+        showMonthAfterYear:false,
+        yearSuffix:''};
 
-/* Malaysian initialisation for the jQuery UI date picker plugin. */
-/* Written by Mohd Nawawi Mohamad Jamili (nawawi@ronggeng.net). */
-	$.datepicker.regional['ms'] = {
-		closeText: 'Tutup',
-		prevText: '&#x3c;Sebelum',
-		nextText: 'Selepas&#x3e;',
-		currentText: 'hari ini',
-		monthNames: ['Januari','Februari','Mac','April','Mei','Jun',
-		'Julai','Ogos','September','Oktober','November','Disember'],
-		monthNamesShort: ['Jan','Feb','Mac','Apr','Mei','Jun',
-		'Jul','Ogo','Sep','Okt','Nov','Dis'],
-		dayNames: ['Ahad','Isnin','Selasa','Rabu','Khamis','Jumaat','Sabtu'],
-		dayNamesShort: ['Aha','Isn','Sel','Rab','kha','Jum','Sab'],
-		dayNamesMin: ['Ah','Is','Se','Ra','Kh','Ju','Sa'],
-		weekHeader: 'Mg',
-		dateFormat: 'dd/mm/yy',
-		firstDay: 0,
-		isRTL: false,
-		showMonthAfterYear: false,
-		yearSuffix: ''};
+    /* Malaysian initialisation for the jQuery UI date picker plugin. */
+    /* Written by Mohd Nawawi Mohamad Jamili (nawawi@ronggeng.net). */
+    $.datepicker.regional['ms'] = {
+        closeText:'Tutup',
+        prevText:'&#x3c;Sebelum',
+        nextText:'Selepas&#x3e;',
+        currentText:'hari ini',
+        monthNames:['Januari', 'Februari', 'Mac', 'April', 'Mei', 'Jun',
+            'Julai', 'Ogos', 'September', 'Oktober', 'November', 'Disember'],
+        monthNamesShort:['Jan', 'Feb', 'Mac', 'Apr', 'Mei', 'Jun',
+            'Jul', 'Ogo', 'Sep', 'Okt', 'Nov', 'Dis'],
+        dayNames:['Ahad', 'Isnin', 'Selasa', 'Rabu', 'Khamis', 'Jumaat', 'Sabtu'],
+        dayNamesShort:['Aha', 'Isn', 'Sel', 'Rab', 'kha', 'Jum', 'Sab'],
+        dayNamesMin:['Ah', 'Is', 'Se', 'Ra', 'Kh', 'Ju', 'Sa'],
+        weekHeader:'Mg',
+        dateFormat:'dd/mm/yy',
+        firstDay:0,
+        isRTL:false,
+        showMonthAfterYear:false,
+        yearSuffix:''};
 
-/* Dutch (UTF-8) initialisation for the jQuery UI date picker plugin. */
-/* Written by Mathias Bynens <http://mathiasbynens.be/> */
-	$.datepicker.regional.nl = {
-		closeText: 'Sluiten',
-		prevText: '←',
-		nextText: '→',
-		currentText: 'Vandaag',
-		monthNames: ['januari', 'februari', 'maart', 'april', 'mei', 'juni',
-		'juli', 'augustus', 'september', 'oktober', 'november', 'december'],
-		monthNamesShort: ['jan', 'feb', 'mrt', 'apr', 'mei', 'jun',
-		'jul', 'aug', 'sep', 'okt', 'nov', 'dec'],
-		dayNames: ['zondag', 'maandag', 'dinsdag', 'woensdag', 'donderdag', 'vrijdag', 'zaterdag'],
-		dayNamesShort: ['zon', 'maa', 'din', 'woe', 'don', 'vri', 'zat'],
-		dayNamesMin: ['zo', 'ma', 'di', 'wo', 'do', 'vr', 'za'],
-		weekHeader: 'Wk',
-		dateFormat: 'dd-mm-yy',
-		firstDay: 1,
-		isRTL: false,
-		showMonthAfterYear: false,
-		yearSuffix: ''};
+    /* Dutch (UTF-8) initialisation for the jQuery UI date picker plugin. */
+    /* Written by Mathias Bynens <http://mathiasbynens.be/> */
+    $.datepicker.regional.nl = {
+        closeText:'Sluiten',
+        prevText:'←',
+        nextText:'→',
+        currentText:'Vandaag',
+        monthNames:['januari', 'februari', 'maart', 'april', 'mei', 'juni',
+            'juli', 'augustus', 'september', 'oktober', 'november', 'december'],
+        monthNamesShort:['jan', 'feb', 'mrt', 'apr', 'mei', 'jun',
+            'jul', 'aug', 'sep', 'okt', 'nov', 'dec'],
+        dayNames:['zondag', 'maandag', 'dinsdag', 'woensdag', 'donderdag', 'vrijdag', 'zaterdag'],
+        dayNamesShort:['zon', 'maa', 'din', 'woe', 'don', 'vri', 'zat'],
+        dayNamesMin:['zo', 'ma', 'di', 'wo', 'do', 'vr', 'za'],
+        weekHeader:'Wk',
+        dateFormat:'dd-mm-yy',
+        firstDay:1,
+        isRTL:false,
+        showMonthAfterYear:false,
+        yearSuffix:''};
 
-/* Norwegian initialisation for the jQuery UI date picker plugin. */
-/* Written by Naimdjon Takhirov (naimdjon@gmail.com). */
-  $.datepicker.regional['no'] = {
-    closeText: 'Lukk',
-    prevText: '&laquo;Forrige',
-    nextText: 'Neste&raquo;',
-    currentText: 'I dag',
-    monthNames: ['januar','februar','mars','april','mai','juni','juli','august','september','oktober','november','desember'],
-    monthNamesShort: ['jan','feb','mar','apr','mai','jun','jul','aug','sep','okt','nov','des'],
-    dayNamesShort: ['søn','man','tir','ons','tor','fre','lør'],
-    dayNames: ['søndag','mandag','tirsdag','onsdag','torsdag','fredag','lørdag'],
-    dayNamesMin: ['sø','ma','ti','on','to','fr','lø'],
-    weekHeader: 'Uke',
-    dateFormat: 'dd.mm.yy',
-    firstDay: 1,
-    isRTL: false,
-    showMonthAfterYear: false,
-    yearSuffix: ''
-  };
-/* Polish initialisation for the jQuery UI date picker plugin. */
-/* Written by Jacek Wysocki (jacek.wysocki@gmail.com). */
-	$.datepicker.regional['pl'] = {
-		closeText: 'Zamknij',
-		prevText: '&#x3c;Poprzedni',
-		nextText: 'Następny&#x3e;',
-		currentText: 'Dziś',
-		monthNames: ['Styczeń','Luty','Marzec','Kwiecień','Maj','Czerwiec',
-		'Lipiec','Sierpień','Wrzesień','Październik','Listopad','Grudzień'],
-		monthNamesShort: ['Sty','Lu','Mar','Kw','Maj','Cze',
-		'Lip','Sie','Wrz','Pa','Lis','Gru'],
-		dayNames: ['Niedziela','Poniedziałek','Wtorek','Środa','Czwartek','Piątek','Sobota'],
-		dayNamesShort: ['Nie','Pn','Wt','Śr','Czw','Pt','So'],
-		dayNamesMin: ['N','Pn','Wt','Śr','Cz','Pt','So'],
-		weekHeader: 'Tydz',
-		dateFormat: 'dd.mm.yy',
-		firstDay: 1,
-		isRTL: false,
-		showMonthAfterYear: false,
-		yearSuffix: ''};
-/* Brazilian initialisation for the jQuery UI date picker plugin. */
-/* Written by Leonildo Costa Silva (leocsilva@gmail.com). */
-	$.datepicker.regional['pt-BR'] = {
-		closeText: 'Fechar',
-		prevText: '&#x3c;Anterior',
-		nextText: 'Pr&oacute;ximo&#x3e;',
-		currentText: 'Hoje',
-		monthNames: ['Janeiro','Fevereiro','Mar&ccedil;o','Abril','Maio','Junho',
-		'Julho','Agosto','Setembro','Outubro','Novembro','Dezembro'],
-		monthNamesShort: ['Jan','Fev','Mar','Abr','Mai','Jun',
-		'Jul','Ago','Set','Out','Nov','Dez'],
-		dayNames: ['Domingo','Segunda-feira','Ter&ccedil;a-feira','Quarta-feira','Quinta-feira','Sexta-feira','S&aacute;bado'],
-		dayNamesShort: ['Dom','Seg','Ter','Qua','Qui','Sex','S&aacute;b'],
-		dayNamesMin: ['Dom','Seg','Ter','Qua','Qui','Sex','S&aacute;b'],
-		weekHeader: 'Sm',
-		dateFormat: 'dd/mm/yy',
-		firstDay: 0,
-		isRTL: false,
-		showMonthAfterYear: false,
-		yearSuffix: ''};
+    /* Norwegian initialisation for the jQuery UI date picker plugin. */
+    /* Written by Naimdjon Takhirov (naimdjon@gmail.com). */
+    $.datepicker.regional['no'] = {
+        closeText:'Lukk',
+        prevText:'&laquo;Forrige',
+        nextText:'Neste&raquo;',
+        currentText:'I dag',
+        monthNames:['januar', 'februar', 'mars', 'april', 'mai', 'juni', 'juli', 'august', 'september', 'oktober', 'november', 'desember'],
+        monthNamesShort:['jan', 'feb', 'mar', 'apr', 'mai', 'jun', 'jul', 'aug', 'sep', 'okt', 'nov', 'des'],
+        dayNamesShort:['søn', 'man', 'tir', 'ons', 'tor', 'fre', 'lør'],
+        dayNames:['søndag', 'mandag', 'tirsdag', 'onsdag', 'torsdag', 'fredag', 'lørdag'],
+        dayNamesMin:['sø', 'ma', 'ti', 'on', 'to', 'fr', 'lø'],
+        weekHeader:'Uke',
+        dateFormat:'dd.mm.yy',
+        firstDay:1,
+        isRTL:false,
+        showMonthAfterYear:false,
+        yearSuffix:''
+    };
+    /* Polish initialisation for the jQuery UI date picker plugin. */
+    /* Written by Jacek Wysocki (jacek.wysocki@gmail.com). */
+    $.datepicker.regional['pl'] = {
+        closeText:'Zamknij',
+        prevText:'&#x3c;Poprzedni',
+        nextText:'Następny&#x3e;',
+        currentText:'Dziś',
+        monthNames:['Styczeń', 'Luty', 'Marzec', 'Kwiecień', 'Maj', 'Czerwiec',
+            'Lipiec', 'Sierpień', 'Wrzesień', 'Październik', 'Listopad', 'Grudzień'],
+        monthNamesShort:['Sty', 'Lu', 'Mar', 'Kw', 'Maj', 'Cze',
+            'Lip', 'Sie', 'Wrz', 'Pa', 'Lis', 'Gru'],
+        dayNames:['Niedziela', 'Poniedziałek', 'Wtorek', 'Środa', 'Czwartek', 'Piątek', 'Sobota'],
+        dayNamesShort:['Nie', 'Pn', 'Wt', 'Śr', 'Czw', 'Pt', 'So'],
+        dayNamesMin:['N', 'Pn', 'Wt', 'Śr', 'Cz', 'Pt', 'So'],
+        weekHeader:'Tydz',
+        dateFormat:'dd.mm.yy',
+        firstDay:1,
+        isRTL:false,
+        showMonthAfterYear:false,
+        yearSuffix:''};
+    /* Brazilian initialisation for the jQuery UI date picker plugin. */
+    /* Written by Leonildo Costa Silva (leocsilva@gmail.com). */
+    $.datepicker.regional['pt-BR'] = {
+        closeText:'Fechar',
+        prevText:'&#x3c;Anterior',
+        nextText:'Pr&oacute;ximo&#x3e;',
+        currentText:'Hoje',
+        monthNames:['Janeiro', 'Fevereiro', 'Mar&ccedil;o', 'Abril', 'Maio', 'Junho',
+            'Julho', 'Agosto', 'Setembro', 'Outubro', 'Novembro', 'Dezembro'],
+        monthNamesShort:['Jan', 'Fev', 'Mar', 'Abr', 'Mai', 'Jun',
+            'Jul', 'Ago', 'Set', 'Out', 'Nov', 'Dez'],
+        dayNames:['Domingo', 'Segunda-feira', 'Ter&ccedil;a-feira', 'Quarta-feira', 'Quinta-feira', 'Sexta-feira', 'S&aacute;bado'],
+        dayNamesShort:['Dom', 'Seg', 'Ter', 'Qua', 'Qui', 'Sex', 'S&aacute;b'],
+        dayNamesMin:['Dom', 'Seg', 'Ter', 'Qua', 'Qui', 'Sex', 'S&aacute;b'],
+        weekHeader:'Sm',
+        dateFormat:'dd/mm/yy',
+        firstDay:0,
+        isRTL:false,
+        showMonthAfterYear:false,
+        yearSuffix:''};
 
-/* Portuguese initialisation for the jQuery UI date picker plugin. */
-	$.datepicker.regional['pt'] = {
-		closeText: 'Fechar',
-		prevText: '&#x3c;Anterior',
-		nextText: 'Seguinte',
-		currentText: 'Hoje',
-		monthNames: ['Janeiro','Fevereiro','Mar&ccedil;o','Abril','Maio','Junho',
-		'Julho','Agosto','Setembro','Outubro','Novembro','Dezembro'],
-		monthNamesShort: ['Jan','Fev','Mar','Abr','Mai','Jun',
-		'Jul','Ago','Set','Out','Nov','Dez'],
-		dayNames: ['Domingo','Segunda-feira','Ter&ccedil;a-feira','Quarta-feira','Quinta-feira','Sexta-feira','S&aacute;bado'],
-		dayNamesShort: ['Dom','Seg','Ter','Qua','Qui','Sex','S&aacute;b'],
-		dayNamesMin: ['Dom','Seg','Ter','Qua','Qui','Sex','S&aacute;b'],
-		weekHeader: 'Sem',
-		dateFormat: 'dd/mm/yy',
-		firstDay: 0,
-		isRTL: false,
-		showMonthAfterYear: false,
-		yearSuffix: ''};
+    /* Portuguese initialisation for the jQuery UI date picker plugin. */
+    $.datepicker.regional['pt'] = {
+        closeText:'Fechar',
+        prevText:'&#x3c;Anterior',
+        nextText:'Seguinte',
+        currentText:'Hoje',
+        monthNames:['Janeiro', 'Fevereiro', 'Mar&ccedil;o', 'Abril', 'Maio', 'Junho',
+            'Julho', 'Agosto', 'Setembro', 'Outubro', 'Novembro', 'Dezembro'],
+        monthNamesShort:['Jan', 'Fev', 'Mar', 'Abr', 'Mai', 'Jun',
+            'Jul', 'Ago', 'Set', 'Out', 'Nov', 'Dez'],
+        dayNames:['Domingo', 'Segunda-feira', 'Ter&ccedil;a-feira', 'Quarta-feira', 'Quinta-feira', 'Sexta-feira', 'S&aacute;bado'],
+        dayNamesShort:['Dom', 'Seg', 'Ter', 'Qua', 'Qui', 'Sex', 'S&aacute;b'],
+        dayNamesMin:['Dom', 'Seg', 'Ter', 'Qua', 'Qui', 'Sex', 'S&aacute;b'],
+        weekHeader:'Sem',
+        dateFormat:'dd/mm/yy',
+        firstDay:0,
+        isRTL:false,
+        showMonthAfterYear:false,
+        yearSuffix:''};
 
-/* Romansh initialisation for the jQuery UI date picker plugin. */
-/* Written by Yvonne Gienal (yvonne.gienal@educa.ch). */
-	$.datepicker.regional['rm'] = {
-		closeText: 'Serrar',
-		prevText: '&#x3c;Suandant',
-		nextText: 'Precedent&#x3e;',
-		currentText: 'Actual',
-		monthNames: ['Schaner','Favrer','Mars','Avrigl','Matg','Zercladur', 'Fanadur','Avust','Settember','October','November','December'],
-		monthNamesShort: ['Scha','Fev','Mar','Avr','Matg','Zer', 'Fan','Avu','Sett','Oct','Nov','Dec'],
-		dayNames: ['Dumengia','Glindesdi','Mardi','Mesemna','Gievgia','Venderdi','Sonda'],
-		dayNamesShort: ['Dum','Gli','Mar','Mes','Gie','Ven','Som'],
-		dayNamesMin: ['Du','Gl','Ma','Me','Gi','Ve','So'],
-		weekHeader: 'emna',
-		dateFormat: 'dd/mm/yy',
-		firstDay: 1,
-		isRTL: false,
-		showMonthAfterYear: false,
-		yearSuffix: ''};
+    /* Romansh initialisation for the jQuery UI date picker plugin. */
+    /* Written by Yvonne Gienal (yvonne.gienal@educa.ch). */
+    $.datepicker.regional['rm'] = {
+        closeText:'Serrar',
+        prevText:'&#x3c;Suandant',
+        nextText:'Precedent&#x3e;',
+        currentText:'Actual',
+        monthNames:['Schaner', 'Favrer', 'Mars', 'Avrigl', 'Matg', 'Zercladur', 'Fanadur', 'Avust', 'Settember', 'October', 'November', 'December'],
+        monthNamesShort:['Scha', 'Fev', 'Mar', 'Avr', 'Matg', 'Zer', 'Fan', 'Avu', 'Sett', 'Oct', 'Nov', 'Dec'],
+        dayNames:['Dumengia', 'Glindesdi', 'Mardi', 'Mesemna', 'Gievgia', 'Venderdi', 'Sonda'],
+        dayNamesShort:['Dum', 'Gli', 'Mar', 'Mes', 'Gie', 'Ven', 'Som'],
+        dayNamesMin:['Du', 'Gl', 'Ma', 'Me', 'Gi', 'Ve', 'So'],
+        weekHeader:'emna',
+        dateFormat:'dd/mm/yy',
+        firstDay:1,
+        isRTL:false,
+        showMonthAfterYear:false,
+        yearSuffix:''};
 
-/* Romanian initialisation for the jQuery UI date picker plugin.
- *
- * Written by Edmond L. (ll_edmond@walla.com)
- * and Ionut G. Stan (ionut.g.stan@gmail.com)
- */
-	$.datepicker.regional['ro'] = {
-		closeText: 'Închide',
-		prevText: '&laquo; Luna precedentă',
-		nextText: 'Luna următoare &raquo;',
-		currentText: 'Azi',
-		monthNames: ['Ianuarie','Februarie','Martie','Aprilie','Mai','Iunie',
-		'Iulie','August','Septembrie','Octombrie','Noiembrie','Decembrie'],
-		monthNamesShort: ['Ian', 'Feb', 'Mar', 'Apr', 'Mai', 'Iun',
-		'Iul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
-		dayNames: ['Duminică', 'Luni', 'Marţi', 'Miercuri', 'Joi', 'Vineri', 'Sâmbătă'],
-		dayNamesShort: ['Dum', 'Lun', 'Mar', 'Mie', 'Joi', 'Vin', 'Sâm'],
-		dayNamesMin: ['Du','Lu','Ma','Mi','Jo','Vi','Sâ'],
-		weekHeader: 'Săpt',
-		dateFormat: 'dd.mm.yy',
-		firstDay: 1,
-		isRTL: false,
-		showMonthAfterYear: false,
-		yearSuffix: ''};
+    /* Romanian initialisation for the jQuery UI date picker plugin.
+     *
+     * Written by Edmond L. (ll_edmond@walla.com)
+     * and Ionut G. Stan (ionut.g.stan@gmail.com)
+     */
+    $.datepicker.regional['ro'] = {
+        closeText:'Închide',
+        prevText:'&laquo; Luna precedentă',
+        nextText:'Luna următoare &raquo;',
+        currentText:'Azi',
+        monthNames:['Ianuarie', 'Februarie', 'Martie', 'Aprilie', 'Mai', 'Iunie',
+            'Iulie', 'August', 'Septembrie', 'Octombrie', 'Noiembrie', 'Decembrie'],
+        monthNamesShort:['Ian', 'Feb', 'Mar', 'Apr', 'Mai', 'Iun',
+            'Iul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
+        dayNames:['Duminică', 'Luni', 'Marţi', 'Miercuri', 'Joi', 'Vineri', 'Sâmbătă'],
+        dayNamesShort:['Dum', 'Lun', 'Mar', 'Mie', 'Joi', 'Vin', 'Sâm'],
+        dayNamesMin:['Du', 'Lu', 'Ma', 'Mi', 'Jo', 'Vi', 'Sâ'],
+        weekHeader:'Săpt',
+        dateFormat:'dd.mm.yy',
+        firstDay:1,
+        isRTL:false,
+        showMonthAfterYear:false,
+        yearSuffix:''};
 
-/* Russian (UTF-8) initialisation for the jQuery UI date picker plugin. */
-/* Written by Andrew Stromnov (stromnov@gmail.com). */
-	$.datepicker.regional['ru'] = {
-		closeText: 'Закрыть',
-		prevText: '&#x3c;Пред',
-		nextText: 'След&#x3e;',
-		currentText: 'Сегодня',
-		monthNames: ['Январь','Февраль','Март','Апрель','Май','Июнь',
-		'Июль','Август','Сентябрь','Октябрь','Ноябрь','Декабрь'],
-		monthNamesShort: ['Янв','Фев','Мар','Апр','Май','Июн',
-		'Июл','Авг','Сен','Окт','Ноя','Дек'],
-		dayNames: ['воскресенье','понедельник','вторник','среда','четверг','пятница','суббота'],
-		dayNamesShort: ['вск','пнд','втр','срд','чтв','птн','сбт'],
-		dayNamesMin: ['Вс','Пн','Вт','Ср','Чт','Пт','Сб'],
-		weekHeader: 'Нед',
-		dateFormat: 'dd.mm.yy',
-		firstDay: 1,
-		isRTL: false,
-		showMonthAfterYear: false,
-		yearSuffix: ''};
+    /* Russian (UTF-8) initialisation for the jQuery UI date picker plugin. */
+    /* Written by Andrew Stromnov (stromnov@gmail.com). */
+    $.datepicker.regional['ru'] = {
+        closeText:'Закрыть',
+        prevText:'&#x3c;Пред',
+        nextText:'След&#x3e;',
+        currentText:'Сегодня',
+        monthNames:['Январь', 'Февраль', 'Март', 'Апрель', 'Май', 'Июнь',
+            'Июль', 'Август', 'Сентябрь', 'Октябрь', 'Ноябрь', 'Декабрь'],
+        monthNamesShort:['Янв', 'Фев', 'Мар', 'Апр', 'Май', 'Июн',
+            'Июл', 'Авг', 'Сен', 'Окт', 'Ноя', 'Дек'],
+        dayNames:['воскресенье', 'понедельник', 'вторник', 'среда', 'четверг', 'пятница', 'суббота'],
+        dayNamesShort:['вск', 'пнд', 'втр', 'срд', 'чтв', 'птн', 'сбт'],
+        dayNamesMin:['Вс', 'Пн', 'Вт', 'Ср', 'Чт', 'Пт', 'Сб'],
+        weekHeader:'Нед',
+        dateFormat:'dd.mm.yy',
+        firstDay:1,
+        isRTL:false,
+        showMonthAfterYear:false,
+        yearSuffix:''};
 
-/* Slovak initialisation for the jQuery UI date picker plugin. */
-/* Written by Vojtech Rinik (vojto@hmm.sk). */
-	$.datepicker.regional['sk'] = {
-		closeText: 'Zavrieť',
-		prevText: '&#x3c;Predchádzajúci',
-		nextText: 'Nasledujúci&#x3e;',
-		currentText: 'Dnes',
-		monthNames: ['Január','Február','Marec','Apríl','Máj','Jún',
-		'Júl','August','September','Október','November','December'],
-		monthNamesShort: ['Jan','Feb','Mar','Apr','Máj','Jún',
-		'Júl','Aug','Sep','Okt','Nov','Dec'],
-		dayNames: ['Nedeľa','Pondelok','Utorok','Streda','Štvrtok','Piatok','Sobota'],
-		dayNamesShort: ['Ned','Pon','Uto','Str','Štv','Pia','Sob'],
-		dayNamesMin: ['Ne','Po','Ut','St','Št','Pia','So'],
-		weekHeader: 'Ty',
-		dateFormat: 'dd.mm.yy',
-		firstDay: 1,
-		isRTL: false,
-		showMonthAfterYear: false,
-		yearSuffix: ''};
+    /* Slovak initialisation for the jQuery UI date picker plugin. */
+    /* Written by Vojtech Rinik (vojto@hmm.sk). */
+    $.datepicker.regional['sk'] = {
+        closeText:'Zavrieť',
+        prevText:'&#x3c;Predchádzajúci',
+        nextText:'Nasledujúci&#x3e;',
+        currentText:'Dnes',
+        monthNames:['Január', 'Február', 'Marec', 'Apríl', 'Máj', 'Jún',
+            'Júl', 'August', 'September', 'Október', 'November', 'December'],
+        monthNamesShort:['Jan', 'Feb', 'Mar', 'Apr', 'Máj', 'Jún',
+            'Júl', 'Aug', 'Sep', 'Okt', 'Nov', 'Dec'],
+        dayNames:['Nedeľa', 'Pondelok', 'Utorok', 'Streda', 'Štvrtok', 'Piatok', 'Sobota'],
+        dayNamesShort:['Ned', 'Pon', 'Uto', 'Str', 'Štv', 'Pia', 'Sob'],
+        dayNamesMin:['Ne', 'Po', 'Ut', 'St', 'Št', 'Pia', 'So'],
+        weekHeader:'Ty',
+        dateFormat:'dd.mm.yy',
+        firstDay:1,
+        isRTL:false,
+        showMonthAfterYear:false,
+        yearSuffix:''};
 
-/* Slovenian initialisation for the jQuery UI date picker plugin. */
-/* Written by Jaka Jancar (jaka@kubje.org). */
-/* c = &#x10D;, s = &#x161; z = &#x17E; C = &#x10C; S = &#x160; Z = &#x17D; */
-	$.datepicker.regional['sl'] = {
-		closeText: 'Zapri',
-		prevText: '&lt;Prej&#x161;nji',
-		nextText: 'Naslednji&gt;',
-		currentText: 'Trenutni',
-		monthNames: ['Januar','Februar','Marec','April','Maj','Junij',
-		'Julij','Avgust','September','Oktober','November','December'],
-		monthNamesShort: ['Jan','Feb','Mar','Apr','Maj','Jun',
-		'Jul','Avg','Sep','Okt','Nov','Dec'],
-		dayNames: ['Nedelja','Ponedeljek','Torek','Sreda','&#x10C;etrtek','Petek','Sobota'],
-		dayNamesShort: ['Ned','Pon','Tor','Sre','&#x10C;et','Pet','Sob'],
-		dayNamesMin: ['Ne','Po','To','Sr','&#x10C;e','Pe','So'],
-		weekHeader: 'Teden',
-		dateFormat: 'dd.mm.yy',
-		firstDay: 1,
-		isRTL: false,
-		showMonthAfterYear: false,
-		yearSuffix: ''};
+    /* Slovenian initialisation for the jQuery UI date picker plugin. */
+    /* Written by Jaka Jancar (jaka@kubje.org). */
+    /* c = &#x10D;, s = &#x161; z = &#x17E; C = &#x10C; S = &#x160; Z = &#x17D; */
+    $.datepicker.regional['sl'] = {
+        closeText:'Zapri',
+        prevText:'&lt;Prej&#x161;nji',
+        nextText:'Naslednji&gt;',
+        currentText:'Trenutni',
+        monthNames:['Januar', 'Februar', 'Marec', 'April', 'Maj', 'Junij',
+            'Julij', 'Avgust', 'September', 'Oktober', 'November', 'December'],
+        monthNamesShort:['Jan', 'Feb', 'Mar', 'Apr', 'Maj', 'Jun',
+            'Jul', 'Avg', 'Sep', 'Okt', 'Nov', 'Dec'],
+        dayNames:['Nedelja', 'Ponedeljek', 'Torek', 'Sreda', '&#x10C;etrtek', 'Petek', 'Sobota'],
+        dayNamesShort:['Ned', 'Pon', 'Tor', 'Sre', '&#x10C;et', 'Pet', 'Sob'],
+        dayNamesMin:['Ne', 'Po', 'To', 'Sr', '&#x10C;e', 'Pe', 'So'],
+        weekHeader:'Teden',
+        dateFormat:'dd.mm.yy',
+        firstDay:1,
+        isRTL:false,
+        showMonthAfterYear:false,
+        yearSuffix:''};
 
-/* Albanian initialisation for the jQuery UI date picker plugin. */
-/* Written by Flakron Bytyqi (flakron@gmail.com). */
-	$.datepicker.regional['sq'] = {
-		closeText: 'mbylle',
-		prevText: '&#x3c;mbrapa',
-		nextText: 'Përpara&#x3e;',
-		currentText: 'sot',
-		monthNames: ['Janar','Shkurt','Mars','Prill','Maj','Qershor',
-		'Korrik','Gusht','Shtator','Tetor','Nëntor','Dhjetor'],
-		monthNamesShort: ['Jan','Shk','Mar','Pri','Maj','Qer',
-		'Kor','Gus','Sht','Tet','Nën','Dhj'],
-		dayNames: ['E Diel','E Hënë','E Martë','E Mërkurë','E Enjte','E Premte','E Shtune'],
-		dayNamesShort: ['Di','Hë','Ma','Më','En','Pr','Sh'],
-		dayNamesMin: ['Di','Hë','Ma','Më','En','Pr','Sh'],
-		weekHeader: 'Ja',
-		dateFormat: 'dd.mm.yy',
-		firstDay: 1,
-		isRTL: false,
-		showMonthAfterYear: false,
-		yearSuffix: ''};
+    /* Albanian initialisation for the jQuery UI date picker plugin. */
+    /* Written by Flakron Bytyqi (flakron@gmail.com). */
+    $.datepicker.regional['sq'] = {
+        closeText:'mbylle',
+        prevText:'&#x3c;mbrapa',
+        nextText:'Përpara&#x3e;',
+        currentText:'sot',
+        monthNames:['Janar', 'Shkurt', 'Mars', 'Prill', 'Maj', 'Qershor',
+            'Korrik', 'Gusht', 'Shtator', 'Tetor', 'Nëntor', 'Dhjetor'],
+        monthNamesShort:['Jan', 'Shk', 'Mar', 'Pri', 'Maj', 'Qer',
+            'Kor', 'Gus', 'Sht', 'Tet', 'Nën', 'Dhj'],
+        dayNames:['E Diel', 'E Hënë', 'E Martë', 'E Mërkurë', 'E Enjte', 'E Premte', 'E Shtune'],
+        dayNamesShort:['Di', 'Hë', 'Ma', 'Më', 'En', 'Pr', 'Sh'],
+        dayNamesMin:['Di', 'Hë', 'Ma', 'Më', 'En', 'Pr', 'Sh'],
+        weekHeader:'Ja',
+        dateFormat:'dd.mm.yy',
+        firstDay:1,
+        isRTL:false,
+        showMonthAfterYear:false,
+        yearSuffix:''};
 
-/* Serbian i18n for the jQuery UI date picker plugin. */
-/* Written by Dejan Dimić. */
-	$.datepicker.regional['sr-SR'] = {
-		closeText: 'Zatvori',
-		prevText: '&#x3c;',
-		nextText: '&#x3e;',
-		currentText: 'Danas',
-		monthNames: ['Januar','Februar','Mart','April','Maj','Jun',
-		'Jul','Avgust','Septembar','Oktobar','Novembar','Decembar'],
-		monthNamesShort: ['Jan','Feb','Mar','Apr','Maj','Jun',
-		'Jul','Avg','Sep','Okt','Nov','Dec'],
-		dayNames: ['Nedelja','Ponedeljak','Utorak','Sreda','Četvrtak','Petak','Subota'],
-		dayNamesShort: ['Ned','Pon','Uto','Sre','Čet','Pet','Sub'],
-		dayNamesMin: ['Ne','Po','Ut','Sr','Če','Pe','Su'],
-		weekHeader: 'Sed',
-		dateFormat: 'dd/mm/yy',
-		firstDay: 1,
-		isRTL: false,
-		showMonthAfterYear: false,
-		yearSuffix: ''};
+    /* Serbian i18n for the jQuery UI date picker plugin. */
+    /* Written by Dejan Dimić. */
+    $.datepicker.regional['sr-SR'] = {
+        closeText:'Zatvori',
+        prevText:'&#x3c;',
+        nextText:'&#x3e;',
+        currentText:'Danas',
+        monthNames:['Januar', 'Februar', 'Mart', 'April', 'Maj', 'Jun',
+            'Jul', 'Avgust', 'Septembar', 'Oktobar', 'Novembar', 'Decembar'],
+        monthNamesShort:['Jan', 'Feb', 'Mar', 'Apr', 'Maj', 'Jun',
+            'Jul', 'Avg', 'Sep', 'Okt', 'Nov', 'Dec'],
+        dayNames:['Nedelja', 'Ponedeljak', 'Utorak', 'Sreda', 'Četvrtak', 'Petak', 'Subota'],
+        dayNamesShort:['Ned', 'Pon', 'Uto', 'Sre', 'Čet', 'Pet', 'Sub'],
+        dayNamesMin:['Ne', 'Po', 'Ut', 'Sr', 'Če', 'Pe', 'Su'],
+        weekHeader:'Sed',
+        dateFormat:'dd/mm/yy',
+        firstDay:1,
+        isRTL:false,
+        showMonthAfterYear:false,
+        yearSuffix:''};
 
-/* Serbian i18n for the jQuery UI date picker plugin. */
-/* Written by Dejan Dimić. */
-	$.datepicker.regional['sr'] = {
-		closeText: 'Затвори',
-		prevText: '&#x3c;',
-		nextText: '&#x3e;',
-		currentText: 'Данас',
-		monthNames: ['Јануар','Фебруар','Март','Април','Мај','Јун',
-		'Јул','Август','Септембар','Октобар','Новембар','Децембар'],
-		monthNamesShort: ['Јан','Феб','Мар','Апр','Мај','Јун',
-		'Јул','Авг','Сеп','Окт','Нов','Дец'],
-		dayNames: ['Недеља','Понедељак','Уторак','Среда','Четвртак','Петак','Субота'],
-		dayNamesShort: ['Нед','Пон','Уто','Сре','Чет','Пет','Суб'],
-		dayNamesMin: ['Не','По','Ут','Ср','Че','Пе','Су'],
-		weekHeader: 'Сед',
-		dateFormat: 'dd/mm/yy',
-		firstDay: 1,
-		isRTL: false,
-		showMonthAfterYear: false,
-		yearSuffix: ''};
+    /* Serbian i18n for the jQuery UI date picker plugin. */
+    /* Written by Dejan Dimić. */
+    $.datepicker.regional['sr'] = {
+        closeText:'Затвори',
+        prevText:'&#x3c;',
+        nextText:'&#x3e;',
+        currentText:'Данас',
+        monthNames:['Јануар', 'Фебруар', 'Март', 'Април', 'Мај', 'Јун',
+            'Јул', 'Август', 'Септембар', 'Октобар', 'Новембар', 'Децембар'],
+        monthNamesShort:['Јан', 'Феб', 'Мар', 'Апр', 'Мај', 'Јун',
+            'Јул', 'Авг', 'Сеп', 'Окт', 'Нов', 'Дец'],
+        dayNames:['Недеља', 'Понедељак', 'Уторак', 'Среда', 'Четвртак', 'Петак', 'Субота'],
+        dayNamesShort:['Нед', 'Пон', 'Уто', 'Сре', 'Чет', 'Пет', 'Суб'],
+        dayNamesMin:['Не', 'По', 'Ут', 'Ср', 'Че', 'Пе', 'Су'],
+        weekHeader:'Сед',
+        dateFormat:'dd/mm/yy',
+        firstDay:1,
+        isRTL:false,
+        showMonthAfterYear:false,
+        yearSuffix:''};
 
-/* Swedish initialisation for the jQuery UI date picker plugin. */
-/* Written by Anders Ekdahl ( anders@nomadiz.se). */
+    /* Swedish initialisation for the jQuery UI date picker plugin. */
+    /* Written by Anders Ekdahl ( anders@nomadiz.se). */
     $.datepicker.regional['sv'] = {
-		closeText: 'Stäng',
-        prevText: '&laquo;Förra',
-		nextText: 'Nästa&raquo;',
-		currentText: 'Idag',
-        monthNames: ['Januari','Februari','Mars','April','Maj','Juni',
-        'Juli','Augusti','September','Oktober','November','December'],
-        monthNamesShort: ['Jan','Feb','Mar','Apr','Maj','Jun',
-        'Jul','Aug','Sep','Okt','Nov','Dec'],
-		dayNamesShort: ['Sön','Mån','Tis','Ons','Tor','Fre','Lör'],
-		dayNames: ['Söndag','Måndag','Tisdag','Onsdag','Torsdag','Fredag','Lördag'],
-		dayNamesMin: ['Sö','Må','Ti','On','To','Fr','Lö'],
-		weekHeader: 'Ve',
-        dateFormat: 'yy-mm-dd',
-		firstDay: 1,
-		isRTL: false,
-		showMonthAfterYear: false,
-		yearSuffix: ''};
+        closeText:'Stäng',
+        prevText:'&laquo;Förra',
+        nextText:'Nästa&raquo;',
+        currentText:'Idag',
+        monthNames:['Januari', 'Februari', 'Mars', 'April', 'Maj', 'Juni',
+            'Juli', 'Augusti', 'September', 'Oktober', 'November', 'December'],
+        monthNamesShort:['Jan', 'Feb', 'Mar', 'Apr', 'Maj', 'Jun',
+            'Jul', 'Aug', 'Sep', 'Okt', 'Nov', 'Dec'],
+        dayNamesShort:['Sön', 'Mån', 'Tis', 'Ons', 'Tor', 'Fre', 'Lör'],
+        dayNames:['Söndag', 'Måndag', 'Tisdag', 'Onsdag', 'Torsdag', 'Fredag', 'Lördag'],
+        dayNamesMin:['Sö', 'Må', 'Ti', 'On', 'To', 'Fr', 'Lö'],
+        weekHeader:'Ve',
+        dateFormat:'yy-mm-dd',
+        firstDay:1,
+        isRTL:false,
+        showMonthAfterYear:false,
+        yearSuffix:''};
 
-/* Tamil (UTF-8) initialisation for the jQuery UI date picker plugin. */
-/* Written by S A Sureshkumar (saskumar@live.com). */
-	$.datepicker.regional['ta'] = {
-		closeText: 'மூடு',
-		prevText: 'முன்னையது',
-		nextText: 'அடுத்தது',
-		currentText: 'இன்று',
-		monthNames: ['தை','மாசி','பங்குனி','சித்திரை','வைகாசி','ஆனி',
-		'ஆடி','ஆவணி','புரட்டாசி','ஐப்பசி','கார்த்திகை','மார்கழி'],
-		monthNamesShort: ['தை','மாசி','பங்','சித்','வைகா','ஆனி',
-		'ஆடி','ஆவ','புர','ஐப்','கார்','மார்'],
-		dayNames: ['ஞாயிற்றுக்கிழமை','திங்கட்கிழமை','செவ்வாய்க்கிழமை','புதன்கிழமை','வியாழக்கிழமை','வெள்ளிக்கிழமை','சனிக்கிழமை'],
-		dayNamesShort: ['ஞாயிறு','திங்கள்','செவ்வாய்','புதன்','வியாழன்','வெள்ளி','சனி'],
-		dayNamesMin: ['ஞா','தி','செ','பு','வி','வெ','ச'],
-		weekHeader: 'Не',
-		dateFormat: 'dd/mm/yy',
-		firstDay: 1,
-		isRTL: false,
-		showMonthAfterYear: false,
-		yearSuffix: ''};
+    /* Tamil (UTF-8) initialisation for the jQuery UI date picker plugin. */
+    /* Written by S A Sureshkumar (saskumar@live.com). */
+    $.datepicker.regional['ta'] = {
+        closeText:'மூடு',
+        prevText:'முன்னையது',
+        nextText:'அடுத்தது',
+        currentText:'இன்று',
+        monthNames:['தை', 'மாசி', 'பங்குனி', 'சித்திரை', 'வைகாசி', 'ஆனி',
+            'ஆடி', 'ஆவணி', 'புரட்டாசி', 'ஐப்பசி', 'கார்த்திகை', 'மார்கழி'],
+        monthNamesShort:['தை', 'மாசி', 'பங்', 'சித்', 'வைகா', 'ஆனி',
+            'ஆடி', 'ஆவ', 'புர', 'ஐப்', 'கார்', 'மார்'],
+        dayNames:['ஞாயிற்றுக்கிழமை', 'திங்கட்கிழமை', 'செவ்வாய்க்கிழமை', 'புதன்கிழமை', 'வியாழக்கிழமை', 'வெள்ளிக்கிழமை', 'சனிக்கிழமை'],
+        dayNamesShort:['ஞாயிறு', 'திங்கள்', 'செவ்வாய்', 'புதன்', 'வியாழன்', 'வெள்ளி', 'சனி'],
+        dayNamesMin:['ஞா', 'தி', 'செ', 'பு', 'வி', 'வெ', 'ச'],
+        weekHeader:'Не',
+        dateFormat:'dd/mm/yy',
+        firstDay:1,
+        isRTL:false,
+        showMonthAfterYear:false,
+        yearSuffix:''};
 
-/* Thai initialisation for the jQuery UI date picker plugin. */
-/* Written by pipo (pipo@sixhead.com). */
-	$.datepicker.regional['th'] = {
-		closeText: 'ปิด',
-		prevText: '&laquo;&nbsp;ย้อน',
-		nextText: 'ถัดไป&nbsp;&raquo;',
-		currentText: 'วันนี้',
-		monthNames: ['มกราคม','กุมภาพันธ์','มีนาคม','เมษายน','พฤษภาคม','มิถุนายน',
-		'กรกฎาคม','สิงหาคม','กันยายน','ตุลาคม','พฤศจิกายน','ธันวาคม'],
-		monthNamesShort: ['ม.ค.','ก.พ.','มี.ค.','เม.ย.','พ.ค.','มิ.ย.',
-		'ก.ค.','ส.ค.','ก.ย.','ต.ค.','พ.ย.','ธ.ค.'],
-		dayNames: ['อาทิตย์','จันทร์','อังคาร','พุธ','พฤหัสบดี','ศุกร์','เสาร์'],
-		dayNamesShort: ['อา.','จ.','อ.','พ.','พฤ.','ศ.','ส.'],
-		dayNamesMin: ['อา.','จ.','อ.','พ.','พฤ.','ศ.','ส.'],
-		weekHeader: 'Wk',
-		dateFormat: 'dd/mm/yy',
-		firstDay: 0,
-		isRTL: false,
-		showMonthAfterYear: false,
-		yearSuffix: ''};
+    /* Thai initialisation for the jQuery UI date picker plugin. */
+    /* Written by pipo (pipo@sixhead.com). */
+    $.datepicker.regional['th'] = {
+        closeText:'ปิด',
+        prevText:'&laquo;&nbsp;ย้อน',
+        nextText:'ถัดไป&nbsp;&raquo;',
+        currentText:'วันนี้',
+        monthNames:['มกราคม', 'กุมภาพันธ์', 'มีนาคม', 'เมษายน', 'พฤษภาคม', 'มิถุนายน',
+            'กรกฎาคม', 'สิงหาคม', 'กันยายน', 'ตุลาคม', 'พฤศจิกายน', 'ธันวาคม'],
+        monthNamesShort:['ม.ค.', 'ก.พ.', 'มี.ค.', 'เม.ย.', 'พ.ค.', 'มิ.ย.',
+            'ก.ค.', 'ส.ค.', 'ก.ย.', 'ต.ค.', 'พ.ย.', 'ธ.ค.'],
+        dayNames:['อาทิตย์', 'จันทร์', 'อังคาร', 'พุธ', 'พฤหัสบดี', 'ศุกร์', 'เสาร์'],
+        dayNamesShort:['อา.', 'จ.', 'อ.', 'พ.', 'พฤ.', 'ศ.', 'ส.'],
+        dayNamesMin:['อา.', 'จ.', 'อ.', 'พ.', 'พฤ.', 'ศ.', 'ส.'],
+        weekHeader:'Wk',
+        dateFormat:'dd/mm/yy',
+        firstDay:0,
+        isRTL:false,
+        showMonthAfterYear:false,
+        yearSuffix:''};
 
-/* Tajiki (UTF-8) initialisation for the jQuery UI date picker plugin. */
-/* Written by Abdurahmon Saidov (saidovab@gmail.com). */
-	$.datepicker.regional['tj'] = {
-		closeText: 'Идома',
-		prevText: '&#x3c;Қафо',
-		nextText: 'Пеш&#x3e;',
-		currentText: 'Имрӯз',
-		monthNames: ['Январ','Феврал','Март','Апрел','Май','Июн',
-		'Июл','Август','Сентябр','Октябр','Ноябр','Декабр'],
-		monthNamesShort: ['Янв','Фев','Мар','Апр','Май','Июн',
-		'Июл','Авг','Сен','Окт','Ноя','Дек'],
-		dayNames: ['якшанбе','душанбе','сешанбе','чоршанбе','панҷшанбе','ҷумъа','шанбе'],
-		dayNamesShort: ['якш','душ','сеш','чор','пан','ҷум','шан'],
-		dayNamesMin: ['Як','Дш','Сш','Чш','Пш','Ҷм','Шн'],
-		weekHeader: 'Хф',
-		dateFormat: 'dd.mm.yy',
-		firstDay: 1,
-		isRTL: false,
-		showMonthAfterYear: false,
-		yearSuffix: ''};
+    /* Tajiki (UTF-8) initialisation for the jQuery UI date picker plugin. */
+    /* Written by Abdurahmon Saidov (saidovab@gmail.com). */
+    $.datepicker.regional['tj'] = {
+        closeText:'Идома',
+        prevText:'&#x3c;Қафо',
+        nextText:'Пеш&#x3e;',
+        currentText:'Имрӯз',
+        monthNames:['Январ', 'Феврал', 'Март', 'Апрел', 'Май', 'Июн',
+            'Июл', 'Август', 'Сентябр', 'Октябр', 'Ноябр', 'Декабр'],
+        monthNamesShort:['Янв', 'Фев', 'Мар', 'Апр', 'Май', 'Июн',
+            'Июл', 'Авг', 'Сен', 'Окт', 'Ноя', 'Дек'],
+        dayNames:['якшанбе', 'душанбе', 'сешанбе', 'чоршанбе', 'панҷшанбе', 'ҷумъа', 'шанбе'],
+        dayNamesShort:['якш', 'душ', 'сеш', 'чор', 'пан', 'ҷум', 'шан'],
+        dayNamesMin:['Як', 'Дш', 'Сш', 'Чш', 'Пш', 'Ҷм', 'Шн'],
+        weekHeader:'Хф',
+        dateFormat:'dd.mm.yy',
+        firstDay:1,
+        isRTL:false,
+        showMonthAfterYear:false,
+        yearSuffix:''};
 
-/* Turkish initialisation for the jQuery UI date picker plugin. */
-/* Written by Izzet Emre Erkan (kara@karalamalar.net). */
-	$.datepicker.regional['tr'] = {
-		closeText: 'kapat',
-		prevText: '&#x3c;geri',
-		nextText: 'ileri&#x3e',
-		currentText: 'bugün',
-		monthNames: ['Ocak','Şubat','Mart','Nisan','Mayıs','Haziran',
-		'Temmuz','Ağustos','Eylül','Ekim','Kasım','Aralık'],
-		monthNamesShort: ['Oca','Şub','Mar','Nis','May','Haz',
-		'Tem','Ağu','Eyl','Eki','Kas','Ara'],
-		dayNames: ['Pazar','Pazartesi','Salı','Çarşamba','Perşembe','Cuma','Cumartesi'],
-		dayNamesShort: ['Pz','Pt','Sa','Ça','Pe','Cu','Ct'],
-		dayNamesMin: ['Pz','Pt','Sa','Ça','Pe','Cu','Ct'],
-		weekHeader: 'Hf',
-		dateFormat: 'dd.mm.yy',
-		firstDay: 1,
-		isRTL: false,
-		showMonthAfterYear: false,
-		yearSuffix: ''};
+    /* Turkish initialisation for the jQuery UI date picker plugin. */
+    /* Written by Izzet Emre Erkan (kara@karalamalar.net). */
+    $.datepicker.regional['tr'] = {
+        closeText:'kapat',
+        prevText:'&#x3c;geri',
+        nextText:'ileri&#x3e',
+        currentText:'bugün',
+        monthNames:['Ocak', 'Şubat', 'Mart', 'Nisan', 'Mayıs', 'Haziran',
+            'Temmuz', 'Ağustos', 'Eylül', 'Ekim', 'Kasım', 'Aralık'],
+        monthNamesShort:['Oca', 'Şub', 'Mar', 'Nis', 'May', 'Haz',
+            'Tem', 'Ağu', 'Eyl', 'Eki', 'Kas', 'Ara'],
+        dayNames:['Pazar', 'Pazartesi', 'Salı', 'Çarşamba', 'Perşembe', 'Cuma', 'Cumartesi'],
+        dayNamesShort:['Pz', 'Pt', 'Sa', 'Ça', 'Pe', 'Cu', 'Ct'],
+        dayNamesMin:['Pz', 'Pt', 'Sa', 'Ça', 'Pe', 'Cu', 'Ct'],
+        weekHeader:'Hf',
+        dateFormat:'dd.mm.yy',
+        firstDay:1,
+        isRTL:false,
+        showMonthAfterYear:false,
+        yearSuffix:''};
 
-/* Ukrainian (UTF-8) initialisation for the jQuery UI date picker plugin. */
-/* Written by Maxim Drogobitskiy (maxdao@gmail.com). */
-	$.datepicker.regional['uk'] = {
-		closeText: 'Закрити',
-		prevText: '&#x3c;',
-		nextText: '&#x3e;',
-		currentText: 'Сьогодні',
-		monthNames: ['Січень','Лютий','Березень','Квітень','Травень','Червень',
-		'Липень','Серпень','Вересень','Жовтень','Листопад','Грудень'],
-		monthNamesShort: ['Січ','Лют','Бер','Кві','Тра','Чер',
-		'Лип','Сер','Вер','Жов','Лис','Гру'],
-		dayNames: ['неділя','понеділок','вівторок','середа','четвер','п’ятниця','субота'],
-		dayNamesShort: ['нед','пнд','вів','срд','чтв','птн','сбт'],
-		dayNamesMin: ['Нд','Пн','Вт','Ср','Чт','Пт','Сб'],
-		weekHeader: 'Не',
-		dateFormat: 'dd/mm/yy',
-		firstDay: 1,
-		isRTL: false,
-		showMonthAfterYear: false,
-		yearSuffix: ''};
+    /* Ukrainian (UTF-8) initialisation for the jQuery UI date picker plugin. */
+    /* Written by Maxim Drogobitskiy (maxdao@gmail.com). */
+    $.datepicker.regional['uk'] = {
+        closeText:'Закрити',
+        prevText:'&#x3c;',
+        nextText:'&#x3e;',
+        currentText:'Сьогодні',
+        monthNames:['Січень', 'Лютий', 'Березень', 'Квітень', 'Травень', 'Червень',
+            'Липень', 'Серпень', 'Вересень', 'Жовтень', 'Листопад', 'Грудень'],
+        monthNamesShort:['Січ', 'Лют', 'Бер', 'Кві', 'Тра', 'Чер',
+            'Лип', 'Сер', 'Вер', 'Жов', 'Лис', 'Гру'],
+        dayNames:['неділя', 'понеділок', 'вівторок', 'середа', 'четвер', 'п’ятниця', 'субота'],
+        dayNamesShort:['нед', 'пнд', 'вів', 'срд', 'чтв', 'птн', 'сбт'],
+        dayNamesMin:['Нд', 'Пн', 'Вт', 'Ср', 'Чт', 'Пт', 'Сб'],
+        weekHeader:'Не',
+        dateFormat:'dd/mm/yy',
+        firstDay:1,
+        isRTL:false,
+        showMonthAfterYear:false,
+        yearSuffix:''};
 
-/* Vietnamese initialisation for the jQuery UI date picker plugin. */
-/* Translated by Le Thanh Huy (lthanhhuy@cit.ctu.edu.vn). */
-	$.datepicker.regional['vi'] = {
-		closeText: 'Đóng',
-		prevText: '&#x3c;Trước',
-		nextText: 'Tiếp&#x3e;',
-		currentText: 'Hôm nay',
-		monthNames: ['Tháng Một', 'Tháng Hai', 'Tháng Ba', 'Tháng Tư', 'Tháng Năm', 'Tháng Sáu',
-		'Tháng Bảy', 'Tháng Tám', 'Tháng Chín', 'Tháng Mười', 'Tháng Mười Một', 'Tháng Mười Hai'],
-		monthNamesShort: ['Tháng 1', 'Tháng 2', 'Tháng 3', 'Tháng 4', 'Tháng 5', 'Tháng 6',
-		'Tháng 7', 'Tháng 8', 'Tháng 9', 'Tháng 10', 'Tháng 11', 'Tháng 12'],
-		dayNames: ['Chủ Nhật', 'Thứ Hai', 'Thứ Ba', 'Thứ Tư', 'Thứ Năm', 'Thứ Sáu', 'Thứ Bảy'],
-		dayNamesShort: ['CN', 'T2', 'T3', 'T4', 'T5', 'T6', 'T7'],
-		dayNamesMin: ['CN', 'T2', 'T3', 'T4', 'T5', 'T6', 'T7'],
-		weekHeader: 'Tu',
-		dateFormat: 'dd/mm/yy',
-		firstDay: 0,
-		isRTL: false,
-		showMonthAfterYear: false,
-		yearSuffix: ''};
+    /* Vietnamese initialisation for the jQuery UI date picker plugin. */
+    /* Translated by Le Thanh Huy (lthanhhuy@cit.ctu.edu.vn). */
+    $.datepicker.regional['vi'] = {
+        closeText:'Đóng',
+        prevText:'&#x3c;Trước',
+        nextText:'Tiếp&#x3e;',
+        currentText:'Hôm nay',
+        monthNames:['Tháng Một', 'Tháng Hai', 'Tháng Ba', 'Tháng Tư', 'Tháng Năm', 'Tháng Sáu',
+            'Tháng Bảy', 'Tháng Tám', 'Tháng Chín', 'Tháng Mười', 'Tháng Mười Một', 'Tháng Mười Hai'],
+        monthNamesShort:['Tháng 1', 'Tháng 2', 'Tháng 3', 'Tháng 4', 'Tháng 5', 'Tháng 6',
+            'Tháng 7', 'Tháng 8', 'Tháng 9', 'Tháng 10', 'Tháng 11', 'Tháng 12'],
+        dayNames:['Chủ Nhật', 'Thứ Hai', 'Thứ Ba', 'Thứ Tư', 'Thứ Năm', 'Thứ Sáu', 'Thứ Bảy'],
+        dayNamesShort:['CN', 'T2', 'T3', 'T4', 'T5', 'T6', 'T7'],
+        dayNamesMin:['CN', 'T2', 'T3', 'T4', 'T5', 'T6', 'T7'],
+        weekHeader:'Tu',
+        dateFormat:'dd/mm/yy',
+        firstDay:0,
+        isRTL:false,
+        showMonthAfterYear:false,
+        yearSuffix:''};
 
-/* Chinese initialisation for the jQuery UI date picker plugin. */
-/* Written by Cloudream (cloudream@gmail.com). */
-	$.datepicker.regional['zh-CN'] = {
-		closeText: '关闭',
-		prevText: '&#x3c;上月',
-		nextText: '下月&#x3e;',
-		currentText: '今天',
-		monthNames: ['一月','二月','三月','四月','五月','六月',
-		'七月','八月','九月','十月','十一月','十二月'],
-		monthNamesShort: ['一','二','三','四','五','六',
-		'七','八','九','十','十一','十二'],
-		dayNames: ['星期日','星期一','星期二','星期三','星期四','星期五','星期六'],
-		dayNamesShort: ['周日','周一','周二','周三','周四','周五','周六'],
-		dayNamesMin: ['日','一','二','三','四','五','六'],
-		weekHeader: '周',
-		dateFormat: 'yy-mm-dd',
-		firstDay: 1,
-		isRTL: false,
-		showMonthAfterYear: true,
-		yearSuffix: '年'};
+    /* Chinese initialisation for the jQuery UI date picker plugin. */
+    /* Written by Cloudream (cloudream@gmail.com). */
+    $.datepicker.regional['zh-CN'] = {
+        closeText:'关闭',
+        prevText:'&#x3c;上月',
+        nextText:'下月&#x3e;',
+        currentText:'今天',
+        monthNames:['一月', '二月', '三月', '四月', '五月', '六月',
+            '七月', '八月', '九月', '十月', '十一月', '十二月'],
+        monthNamesShort:['一', '二', '三', '四', '五', '六',
+            '七', '八', '九', '十', '十一', '十二'],
+        dayNames:['星期日', '星期一', '星期二', '星期三', '星期四', '星期五', '星期六'],
+        dayNamesShort:['周日', '周一', '周二', '周三', '周四', '周五', '周六'],
+        dayNamesMin:['日', '一', '二', '三', '四', '五', '六'],
+        weekHeader:'周',
+        dateFormat:'yy-mm-dd',
+        firstDay:1,
+        isRTL:false,
+        showMonthAfterYear:true,
+        yearSuffix:'年'};
 
-/* Chinese initialisation for the jQuery UI date picker plugin. */
-/* Written by SCCY (samuelcychan@gmail.com). */
-	$.datepicker.regional['zh-HK'] = {
-		closeText: '關閉',
-		prevText: '&#x3c;上月',
-		nextText: '下月&#x3e;',
-		currentText: '今天',
-		monthNames: ['一月','二月','三月','四月','五月','六月',
-		'七月','八月','九月','十月','十一月','十二月'],
-		monthNamesShort: ['一','二','三','四','五','六',
-		'七','八','九','十','十一','十二'],
-		dayNames: ['星期日','星期一','星期二','星期三','星期四','星期五','星期六'],
-		dayNamesShort: ['周日','周一','周二','周三','周四','周五','周六'],
-		dayNamesMin: ['日','一','二','三','四','五','六'],
-		weekHeader: '周',
-		dateFormat: 'dd-mm-yy',
-		firstDay: 0,
-		isRTL: false,
-		showMonthAfterYear: true,
-		yearSuffix: '年'};
+    /* Chinese initialisation for the jQuery UI date picker plugin. */
+    /* Written by SCCY (samuelcychan@gmail.com). */
+    $.datepicker.regional['zh-HK'] = {
+        closeText:'關閉',
+        prevText:'&#x3c;上月',
+        nextText:'下月&#x3e;',
+        currentText:'今天',
+        monthNames:['一月', '二月', '三月', '四月', '五月', '六月',
+            '七月', '八月', '九月', '十月', '十一月', '十二月'],
+        monthNamesShort:['一', '二', '三', '四', '五', '六',
+            '七', '八', '九', '十', '十一', '十二'],
+        dayNames:['星期日', '星期一', '星期二', '星期三', '星期四', '星期五', '星期六'],
+        dayNamesShort:['周日', '周一', '周二', '周三', '周四', '周五', '周六'],
+        dayNamesMin:['日', '一', '二', '三', '四', '五', '六'],
+        weekHeader:'周',
+        dateFormat:'dd-mm-yy',
+        firstDay:0,
+        isRTL:false,
+        showMonthAfterYear:true,
+        yearSuffix:'年'};
 
-/* Chinese initialisation for the jQuery UI date picker plugin. */
-/* Written by Ressol (ressol@gmail.com). */
-	$.datepicker.regional['zh-TW'] = {
-		closeText: '關閉',
-		prevText: '&#x3c;上月',
-		nextText: '下月&#x3e;',
-		currentText: '今天',
-		monthNames: ['一月','二月','三月','四月','五月','六月',
-		'七月','八月','九月','十月','十一月','十二月'],
-		monthNamesShort: ['一','二','三','四','五','六',
-		'七','八','九','十','十一','十二'],
-		dayNames: ['星期日','星期一','星期二','星期三','星期四','星期五','星期六'],
-		dayNamesShort: ['周日','周一','周二','周三','周四','周五','周六'],
-		dayNamesMin: ['日','一','二','三','四','五','六'],
-		weekHeader: '周',
-		dateFormat: 'yy/mm/dd',
-		firstDay: 1,
-		isRTL: false,
-		showMonthAfterYear: true,
-		yearSuffix: '年'};
+    /* Chinese initialisation for the jQuery UI date picker plugin. */
+    /* Written by Ressol (ressol@gmail.com). */
+    $.datepicker.regional['zh-TW'] = {
+        closeText:'關閉',
+        prevText:'&#x3c;上月',
+        nextText:'下月&#x3e;',
+        currentText:'今天',
+        monthNames:['一月', '二月', '三月', '四月', '五月', '六月',
+            '七月', '八月', '九月', '十月', '十一月', '十二月'],
+        monthNamesShort:['一', '二', '三', '四', '五', '六',
+            '七', '八', '九', '十', '十一', '十二'],
+        dayNames:['星期日', '星期一', '星期二', '星期三', '星期四', '星期五', '星期六'],
+        dayNamesShort:['周日', '周一', '周二', '周三', '周四', '周五', '周六'],
+        dayNamesMin:['日', '一', '二', '三', '四', '五', '六'],
+        weekHeader:'周',
+        dateFormat:'yy/mm/dd',
+        firstDay:1,
+        isRTL:false,
+        showMonthAfterYear:true,
+        yearSuffix:'年'};
 
-$.datepicker.setDefaults($.datepicker.regional['en-GB']);
+    $.datepicker.setDefaults($.datepicker.regional['en-GB']);
 });


### PR DESCRIPTION
Remove useless `$(document).ready()` calls (only one is needed), remove all the useless calls to `$.datepicker.setDefaults();` and most important, set the default as **_en-GB**_.

With the previous code, the last `$.datepicker.setDefaults();` was Chinese, so all the datepickers without a matched culture was displayed in Chinese.

There was also a lot of tabs and bad formatting, fixed too.
